### PR TITLE
Replaces the Android package name to match the namespace.

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="fr.greweb.reactnativeviewshot">
 
 </manifest>
-  


### PR DESCRIPTION
Thank you for the great library.

When you link, React Native was picking up the wrong namespace to import into our `MainApplication.java`.  This patches that up.