### PR TITLE
Invalidates the Android view cache after each shot.

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -94,10 +94,11 @@ public class ViewShot implements UIBlock {
         if (w <= 0 || h <= 0) {
             throw new RuntimeException("Impossible to snapshot the view: view is invalid");
         }
+        if (!view.isDrawingCacheEnabled())
+          view.setDrawingCacheEnabled(true);
+
         Bitmap bitmap = view.getDrawingCache();
-        if (bitmap == null)
-            view.setDrawingCacheEnabled(true);
-        bitmap = view.getDrawingCache();
+
         if (width != null && height != null && (width != w || height != h)) {
             bitmap = Bitmap.createScaledBitmap(bitmap, width, height, true);
         }
@@ -105,5 +106,6 @@ public class ViewShot implements UIBlock {
             throw new RuntimeException("Impossible to snapshot the view");
         }
         bitmap.compress(format, (int)(100.0 * quality), os);
+        view.setDrawingCacheEnabled(false);
     }
 }


### PR DESCRIPTION
Currently, you get 1 chance per-view on Android.  It never expires the drawing cache after 1st shot.  

This is a fix for that.