### PR TITLE
Adds base64 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Returns a Promise of the image URI.
  - **`width`** / **`height`** *(number)*: the width and height of the image to capture.
  - **`format`** *(string)*: either `png` or `jpg`/`jpeg` or `webm` (Android). Defaults to `png`.
  - **`quality`** *(number)*: the quality. 0.0 - 1.0 (default). (only available on lossy formats like jpeg)
+ - **`base64`** *(bool)*: if true, the promise returns the base64 encoded data instead of the uri. Defaults to `false`.
 
 
 ## Getting started

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
@@ -61,10 +61,11 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
         DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
         Integer width = options.hasKey("width") ? (int)(displayMetrics.density * options.getDouble("width")) : null;
         Integer height = options.hasKey("height") ? (int)(displayMetrics.density * options.getDouble("height")) : null;
+        boolean base64 = options.hasKey("base64") ? options.getBoolean("base64") : false;
         try {
             File tmpFile = createTempFile(getReactApplicationContext(), format);
             UIManagerModule uiManager = this.reactContext.getNativeModule(UIManagerModule.class);
-            uiManager.addUIBlock(new ViewShot(tag, compressFormat, quality, width, height, tmpFile, promise));
+            uiManager.addUIBlock(new ViewShot(tag, compressFormat, quality, width, height, tmpFile, base64, promise));
         }
         catch (Exception e) {
             promise.reject(ViewShot.ERROR_UNABLE_TO_SNAPSHOT, "Failed to snapshot view tag "+tag);

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ export function takeSnapshot(
     height ?: number;
     format ?: "png" | "jpg" | "jpeg" | "webm";
     quality ?: number;
+    base64 ?: bool;
   }
 ): Promise<string> {
   if (typeof view !== "number") {

--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -70,13 +70,20 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)target
                 return;
             }
 
-            // Save to a temp file
             NSError *error = nil;
-            NSString *tempFilePath = RCTTempFilePath(format, &error);
-            if (tempFilePath) {
-                if ([data writeToFile:tempFilePath options:(NSDataWritingOptions)0 error:&error]) {
-                    resolve(tempFilePath);
-                    return;
+            if ([[options objectForKey:@"base64"] boolValue]) {
+                // Return as a base64'd string
+                NSString *dataString = [data base64EncodedStringWithOptions:0];
+                resolve(dataString);
+                return;
+            } else {
+                // Save to a temp file
+                NSString *tempFilePath = RCTTempFilePath(format, &error);
+                if (tempFilePath) {
+                    if ([data writeToFile:tempFilePath options:(NSDataWritingOptions)0 error:&error]) {
+                        resolve(tempFilePath);
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
I have a use case where I'd like to stream the data from the a running app to a server over websockets for display in a reactjs app.

This adds a boolean flag to the opts called `base64`.  When true, the promise resolves to a base64 encoded string instead of a uri.

```js
    RNViewShot
      .takeSnapshot(this.refs.foo, { base64: true })
      .then(...)
```

Now, granted, it's not the nicest API interface, but I didn't want to stomp over what you had.  I'd figure submit this, see what's up first.

** Full Disclosure ** I didn't test the flow changes to `index.js`.  I kinda don't know how 👀 .

Thanks again for your work on this lib.

I'm making a plugin for https://github.com/reactotron/reactotron to take screenshots of your device.

![image](https://cloud.githubusercontent.com/assets/68273/17957086/b0c9aab8-6a5c-11e6-87d6-a58f2543d2ec.png)
