### PR TITLE
Fix generated file extension for Android

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
@@ -135,7 +135,8 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
             cacheDir = externalCacheDir.getFreeSpace() > internalCacheDir.getFreeSpace() ?
                     externalCacheDir : internalCacheDir;
         }
-        return File.createTempFile(TEMP_FILE_PREFIX, ext, cacheDir);
+        String suffix = "." + ext;
+        return File.createTempFile(TEMP_FILE_PREFIX, suffix, cacheDir);
     }
 
 }


### PR DESCRIPTION
Hey @gre, great project!!

There was a missing 'dot' in the generated file name for the Android version which caused not to be recognized as an Image when saving it to the camera roll (using CameraRoll.saveToCameraRoll)

Thanks!
Vic