### PR TITLE
Convert image to data in a separate thread

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -1,6 +1,7 @@
 package fr.greweb.reactnativeviewshot;
 
 import javax.annotation.Nullable;
+
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.net.Uri;
@@ -16,6 +17,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Snapshot utility class allow to screenshot a view.
@@ -23,6 +26,8 @@ import java.io.OutputStream;
 public class ViewShot implements UIBlock {
 
     static final String ERROR_UNABLE_TO_SNAPSHOT = "E_UNABLE_TO_SNAPSHOT";
+
+    private final static ExecutorService sExecutor = Executors.newFixedThreadPool(5);
 
     private int tag;
     private String extension;
@@ -57,59 +62,63 @@ public class ViewShot implements UIBlock {
 
     @Override
     public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
-        OutputStream os = null;
         View view = nativeViewHierarchyManager.resolveView(tag);
         if (view == null) {
-            promise.reject(ERROR_UNABLE_TO_SNAPSHOT, "No view found with reactTag: "+tag);
+            promise.reject(ERROR_UNABLE_TO_SNAPSHOT, "No view found with reactTag: " + tag);
             return;
         }
-        try {
-            if ("file".equals(result)) {
-                os = new FileOutputStream(output);
-                captureView(view, os);
-                String uri = Uri.fromFile(output).toString();
-                promise.resolve(uri);
-            }
-            else if ("base64".equals(result)) {
-                os = new ByteArrayOutputStream();
-                captureView(view, os);
-                byte[] bytes = ((ByteArrayOutputStream) os).toByteArray();
-                String data = Base64.encodeToString(bytes, Base64.NO_WRAP);
-                promise.resolve(data);
-            }
-            else if ("data-uri".equals(result)) {
-                os = new ByteArrayOutputStream();
-                captureView(view, os);
-                byte[] bytes = ((ByteArrayOutputStream) os).toByteArray();
-                String data = Base64.encodeToString(bytes, Base64.NO_WRAP);
-                data = "data:image/"+extension+";base64," + data;
-                promise.resolve(data);
-            }
-            else {
-                promise.reject(ERROR_UNABLE_TO_SNAPSHOT, "Unsupported result: "+result+". Try one of: file | base64 | data-uri");
-            }
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-            promise.reject(ERROR_UNABLE_TO_SNAPSHOT, "Failed to capture view snapshot");
-        }
-        finally {
-            if (os != null) {
+        final Bitmap bitmap = captureView(view);
+        sExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                OutputStream os = null;
                 try {
-                    os.close();
-                } catch (IOException e) {
+                    if ("file".equals(result)) {
+                        os = new FileOutputStream(output);
+                        String uri = Uri.fromFile(output).toString();
+                        promise.resolve(uri);
+                    } else if ("base64".equals(result)) {
+                        os = new ByteArrayOutputStream();
+                        convertImageToData(bitmap, os);
+                        byte[] bytes = ((ByteArrayOutputStream) os).toByteArray();
+                        String data = Base64.encodeToString(bytes, Base64.NO_WRAP);
+                        promise.resolve(data);
+                    } else if ("data-uri".equals(result)) {
+                        os = new ByteArrayOutputStream();
+                        convertImageToData(bitmap, os);
+                        byte[] bytes = ((ByteArrayOutputStream) os).toByteArray();
+                        String data = Base64.encodeToString(bytes, Base64.NO_WRAP);
+                        data = "data:image/" + extension + ";base64," + data;
+                        promise.resolve(data);
+                    } else {
+                        promise.reject(ERROR_UNABLE_TO_SNAPSHOT, "Unsupported result: " + result +
+                                ". Try one of: file | base64 | data-uri");
+                    }
+                } catch (Exception e) {
                     e.printStackTrace();
+                    promise.reject(ERROR_UNABLE_TO_SNAPSHOT, "Failed to capture view snapshot");
+                } finally {
+                    if (os != null) {
+                        try {
+                            os.close();
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                    }
                 }
             }
-        }
+        });
+
+
     }
 
     /**
      * Screenshot a view and return the captured bitmap.
+     *
      * @param view the view to capture
-     * @return the screenshot or null if it failed.
+     * @return bitmap drawn by view
      */
-    private void captureView (View view, OutputStream os) {
+    private Bitmap captureView(View view) {
         int w = view.getWidth();
         int h = view.getHeight();
         if (w <= 0 || h <= 0) {
@@ -125,6 +134,17 @@ public class ViewShot implements UIBlock {
         if (bitmap == null) {
             throw new RuntimeException("Impossible to snapshot the view");
         }
-        bitmap.compress(format, (int)(100.0 * quality), os);
+        return bitmap;
+    }
+
+    /**
+     * As Bitmap.compress() may take a long time, it's better to
+     * call it in a separate thread
+     *
+     * @param bitmap image to convert
+     * @param os     output stream
+     */
+    private void convertImageToData(Bitmap bitmap, OutputStream os) {
+        bitmap.compress(format, (int) (100.0 * quality), os);
     }
 }


### PR DESCRIPTION
Hi Gaëtan,

When I apply the module to my app, I found that it may decrease UI performance when multi images are captured. It is caused by `Bitmap.compress()` which may take a long time. Therefore, I think it would be better to call it in a separate thread, which has been done in your iOS code. Please check my PR for detail.

Thanks and regards,
Lionel