### PR TITLE
React Native 40 - Not Backwards Compatible ⚠️

### DIFF
--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -1,12 +1,12 @@
 
 #import "RNViewShot.h"
 #import <AVFoundation/AVFoundation.h>
-#import "React/RCTLog.h"
-#import "React/UIView+React.h"
-#import "React/RCTUtils.h"
-#import "React/RCTConvert.h"
-#import "React/RCTUIManager.h"
-#import "React/RCTBridge.h"
+#import <React/RCTLog.h>
+#import <React/UIView+React.h>
+#import <React/RCTUtils.h>
+#import <React/RCTConvert.h>
+#import <React/RCTUIManager.h>
+#import <React/RCTBridge.h>
 
 
 @implementation RNViewShot

--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -1,12 +1,12 @@
 
 #import "RNViewShot.h"
 #import <AVFoundation/AVFoundation.h>
-#import "RCTLog.h"
-#import "UIView+React.h"
-#import "RCTUtils.h"
-#import "RCTConvert.h"
-#import "RCTUIManager.h"
-#import "RCTBridge.h"
+#import "React/RCTLog.h"
+#import "React/UIView+React.h"
+#import "React/RCTUtils.h"
+#import "React/RCTConvert.h"
+#import "React/RCTUIManager.h"
+#import "React/RCTBridge.h"
 
 
 @implementation RNViewShot


### PR DESCRIPTION
Not sure how you want to deal with this, but I thought I'd throw it out there.

So, React Native 40 is Armageddon for 3rd party native modules.

We just need to qualify the [React-* headers](https://github.com/facebook/react-native/releases/tag/v0.40.0).

But this is not compatible with anything under 40.  😿 

![this-is-sparta](https://cloud.githubusercontent.com/assets/68273/21756935/995acb64-d5f5-11e6-86f2-c1d8e5d0a7ea.gif)

Not sure what other authors are doing to support both yet.

