### PR TITLE
Add "repository" key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   ],
   "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gre/react-native-view-shot.git"
+  },
   "peerDependencies": {
     "react-native": "*"
   }


### PR DESCRIPTION
Adding the `repository` key allows the npm registry to link back to the repo.

I ❤️ this thing, though! It just _works so well!_