### PR TITLE
Fix Module Name Error on Android

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
@@ -37,7 +37,7 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
 
     @Override
     public String getName() {
-        return "RNViewShot";
+        return "RNViewShotModule";
     }
 
     @Override


### PR DESCRIPTION
I just tried the module and got this error:

![screenshot_20170507-193100](https://cloud.githubusercontent.com/assets/891585/25780973/926ee8ca-335c-11e7-8e1c-76f21852e704.png)

This appears to be because of module name mismatch. (Yes, I have checked MainActivity file to make sure the module isn't included twice).