### PR TITLE
recursively create folders before creating file

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
@@ -78,6 +78,7 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
             if ("file".equals(result)) {
                 if (options.hasKey("path")) {
                     file = new File(options.getString("path"));
+                    file.mkdirs();
                     file.createNewFile();
                 }
                 else {


### PR DESCRIPTION
### Motivation

I found that we can't use nested paths on android to saving snapshots. So this PR added ability to recursively create folders before taking snapshot.

### Test Plan.

This don't tested, needed to test.