### PR TITLE
Fix iOS Hang by Using Proper Method Queue

### DIFF
--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -18,7 +18,7 @@ RCT_EXPORT_MODULE()
 
 - (dispatch_queue_t)methodQueue
 {
-  return self.bridge.uiManager.methodQueue;
+  return RCTGetUIManagerQueue();
 }
 
 - (NSDictionary *)constantsToExport


### PR DESCRIPTION
I'm using RN 0.42 with a few other libraries and my app hung when loading.  I did some investigation and the `methodQueue` that was currently used is no longer the supported one.  I switched to the supported one and everything works fine.