### PR TITLE
Remove override of 'createJSModules' for RN 0.47

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotPackage.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotPackage.java
@@ -16,7 +16,8 @@ public class RNViewShotPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNViewShotModule(reactContext));
     }
 
-    @Override
+    // Deprecated RN 0.47
+    // @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
This updates the library for the react-native 0.47 breaking change.

https://github.com/facebook/react-native/releases/tag/v0.47.0

This is not a breaking change for this library. Users can continue to update react-native-view-shot without being forced to update RN to >= 0.47. The downside to doing it this way instead of removing it is that there is now dead code for RN >= 0.47.