### PR TITLE
TextureView compatibility on Android as per Issue #57

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -6,16 +6,11 @@ import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.Matrix;
-import android.graphics.Rect;
 import android.net.Uri;
 import android.util.Base64;
-import android.util.Log;
 import android.view.TextureView;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.LinearLayout;
 import android.widget.ScrollView;
 
 import com.facebook.react.bridge.Promise;

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -6,9 +6,16 @@ import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Matrix;
+import android.graphics.Rect;
 import android.net.Uri;
 import android.util.Base64;
+import android.util.Log;
+import android.view.TextureView;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
 import android.widget.ScrollView;
 
 import com.facebook.react.bridge.Promise;
@@ -21,6 +28,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Snapshot utility class allow to screenshot a view.
@@ -116,6 +125,27 @@ public class ViewShot implements UIBlock {
         }
     }
 
+    private List<View> getAllChildren(View v) {
+
+        if (!(v instanceof ViewGroup)) {
+            ArrayList<View> viewArrayList = new ArrayList<View>();
+            viewArrayList.add(v);
+            return viewArrayList;
+        }
+
+        ArrayList<View> result = new ArrayList<View>();
+
+        ViewGroup viewGroup = (ViewGroup) v;
+        for (int i = 0; i < viewGroup.getChildCount(); i++) {
+
+            View child = viewGroup.getChildAt(i);
+
+            //Do not add any parents, just add child elements
+            result.addAll(getAllChildren(child));
+        }
+        return result;
+    }
+
     /**
      * Screenshot a view and return the captured bitmap.
      * @param view the view to capture
@@ -138,8 +168,20 @@ public class ViewShot implements UIBlock {
             }
         }
         Bitmap bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
+        Bitmap childBitmapBuffer;
         Canvas c = new Canvas(bitmap);
         view.draw(c);
+
+        //after view is drawn, go through children
+        List<View> childrenList = getAllChildren(view);
+
+        for (View child : childrenList) {
+            if(child instanceof TextureView) {
+                ((TextureView) child).setOpaque(false);
+                childBitmapBuffer = ((TextureView) child).getBitmap(child.getWidth(), child.getHeight());
+                c.drawBitmap(childBitmapBuffer, child.getLeft() + ((ViewGroup)child.getParent()).getLeft() +  child.getPaddingLeft(), child.getTop() + ((ViewGroup)child.getParent()).getTop() + child.getPaddingTop(), null);
+            }
+        }
 
         if (width != null && height != null && (width != w || height != h)) {
             bitmap = Bitmap.createScaledBitmap(bitmap, width, height, true);


### PR DESCRIPTION
Hi I ran into issue #57 as well and decided to follow the owner's suggestion.

It's a quick hack but it does the job for me.

As per owner's suggestion:
Firstly get all children recursively;
Then check if each child is an instance of TextureView with instanceof;
Make sure child knows it's not opaque and get its bitmap into a buffer;
Draw said bitmap into the current canvas.

This assumes that these TextureView elements are ordered in the tree.

I haven't been able to test properly, but I think it works. Might help someone.