### PR TITLE
Extend Functionality to Include Generic Screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,27 @@ This method release a previously captured `uri`. For tmpfile it will clean them 
 
 NB: the tmpfile captures are automatically cleaned out after the app closes, so you might not have to worry about this unless advanced usecases. The `ViewShot` component will use it each time you capture more than once (useful for continuous capture to not leak files).
 
+## `captureScreen()` Android and iOS Only
+
+```js
+import { captureScreen } from "react-native-view-shot";
+
+captureScreen({
+  format: "jpg",
+  quality: 0.8
+})
+.then(
+  uri => console.log("Image saved to", uri),
+  error => console.error("Oops, snapshot failed", error)
+);
+```
+
+This method will capture the contents of the currently displayed screen as a native hardware screenshot. It does not require a ref input, as it does not work at the view level. This means that ScrollViews will not be captured in their entirety - only the portions currently visible to the user. 
+
+Returns a Promise of the image URI.
+
+- **`options`**: the same options as in `captureRef` method.
+
 ### Advanced Examples
 
 [Checkout react-native-view-shot-example](example)

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
@@ -93,7 +93,7 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void captureScreenshot(ReadableMap options, Promise promise) {
+    public void captureScreen(ReadableMap options, Promise promise) {
         captureRef(-1, options, promise);
     }
 

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
@@ -85,11 +85,16 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
               file = createTempFile(getReactApplicationContext(), format);
             }
             UIManagerModule uiManager = this.reactContext.getNativeModule(UIManagerModule.class);
-            uiManager.addUIBlock(new ViewShot(tag, format, compressFormat, quality, width, height, file, result, snapshotContentContainer,reactContext, promise));
+            uiManager.addUIBlock(new ViewShot(tag, format, compressFormat, quality, width, height, file, result, snapshotContentContainer,reactContext, getCurrentActivity(), promise));
         }
         catch (Exception e) {
             promise.reject(ViewShot.ERROR_UNABLE_TO_SNAPSHOT, "Failed to snapshot view tag "+tag);
         }
+    }
+
+    @ReactMethod
+    public void captureScreenshot(ReadableMap options, Promise promise) {
+        captureRef(-1, options, promise);
     }
 
     private static final String TEMP_FILE_PREFIX = "ReactNative-snapshot-image";

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -44,6 +44,7 @@ public class ViewShot implements UIBlock {
     private Promise promise;
     private Boolean snapshotContentContainer;
     private  ReactApplicationContext reactContext;
+    private Activity currentActivity;
 
     public ViewShot(
             int tag,
@@ -56,6 +57,7 @@ public class ViewShot implements UIBlock {
             String result,
             Boolean snapshotContentContainer,
             ReactApplicationContext reactContext,
+            Activity currentActivity,
             Promise promise) {
         this.tag = tag;
         this.extension = extension;
@@ -67,13 +69,21 @@ public class ViewShot implements UIBlock {
         this.result = result;
         this.snapshotContentContainer = snapshotContentContainer;
         this.reactContext = reactContext;
+        this.currentActivity = currentActivity;
         this.promise = promise;
     }
 
     @Override
     public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
         OutputStream os = null;
-        View view = nativeViewHierarchyManager.resolveView(tag);
+        View view = null;
+
+        if (tag == -1) {
+            view = currentActivity.getWindow().getDecorView().findViewById(android.R.id.content);
+        } else {
+            view = nativeViewHierarchyManager.resolveView(tag);
+        }
+
         if (view == null) {
             promise.reject(ERROR_UNABLE_TO_SNAPSHOT, "No view found with reactTag: "+tag);
             return;

--- a/example/App.js
+++ b/example/App.js
@@ -52,46 +52,9 @@ export default class App extends Component {
       snapshotContentContainer: false
     }
   };
-
-  captureScreenshot = () =>
-    captureScreen(this.state.value)
-      .then(
-        res =>
-          this.state.value.result !== "tmpfile"
-          ? res
-          : new Promise((success, failure) =>
-          // just a test to ensure res can be used in Image.getSize
-          Image.getSize(
-            res,
-            (width, height) => (
-              console.log(res, width, height), success(res)
-            ),
-            failure
-          )
-        )
-      )
-      .then(res =>
-        this.setState({
-          error: null,
-          res,
-          previewSource: {
-            uri:
-              this.state.value.result === "base64"
-                ? "data:image/" + this.state.value.format + ";base64," + res
-                : res
-          }
-        })
-      )
-      .catch(
-        error => (
-          console.warn(error),
-          this.setState({ error, res: null, previewSource: null })
-        )
-      );
-    
-
+  
   snapshot = refname => () =>
-    captureRef(this.refs[refname], this.state.value)
+    (refname ? captureRef(this.refs[refname], this.state.value) : captureScreen(this.state.value))
       .then(
         res =>
           this.state.value.result !== "tmpfile"
@@ -184,7 +147,7 @@ export default class App extends Component {
             <Btn label="📷 MapView" onPress={this.snapshot("mapview")} />
             <Btn label="📷 WebView" onPress={this.snapshot("webview")} />
             <Btn label="📷 Video" onPress={this.snapshot("video")} />
-            <Btn label="📷 Native Screenshot" onPress={this.captureScreenshot}/>
+            <Btn label="📷 Native Screenshot" onPress={this.snapshot()}/>
             <Btn
               label="📷 Empty View (should crash)"
               onPress={this.snapshot("empty")}

--- a/example/App.js
+++ b/example/App.js
@@ -12,7 +12,7 @@ import {
   WebView
 } from "react-native";
 import omit from "lodash/omit";
-import { captureRef } from "react-native-view-shot";
+import { captureRef, captureScreen } from "react-native-view-shot";
 import { Surface } from "gl-react-native";
 import GL from "gl-react";
 import MapView from "react-native-maps";
@@ -52,6 +52,43 @@ export default class App extends Component {
       snapshotContentContainer: false
     }
   };
+
+  captureScreenshot = () =>
+    captureScreen(this.state.value)
+      .then(
+        res =>
+          this.state.value.result !== "tmpfile"
+          ? res
+          : new Promise((success, failure) =>
+          // just a test to ensure res can be used in Image.getSize
+          Image.getSize(
+            res,
+            (width, height) => (
+              console.log(res, width, height), success(res)
+            ),
+            failure
+          )
+        )
+      )
+      .then(res =>
+        this.setState({
+          error: null,
+          res,
+          previewSource: {
+            uri:
+              this.state.value.result === "base64"
+                ? "data:image/" + this.state.value.format + ";base64," + res
+                : res
+          }
+        })
+      )
+      .catch(
+        error => (
+          console.warn(error),
+          this.setState({ error, res: null, previewSource: null })
+        )
+      );
+    
 
   snapshot = refname => () =>
     captureRef(this.refs[refname], this.state.value)
@@ -147,6 +184,7 @@ export default class App extends Component {
             <Btn label="📷 MapView" onPress={this.snapshot("mapview")} />
             <Btn label="📷 WebView" onPress={this.snapshot("webview")} />
             <Btn label="📷 Video" onPress={this.snapshot("video")} />
+            <Btn label="📷 Native Screenshot" onPress={this.captureScreenshot}/>
             <Btn
               label="📷 Empty View (should crash)"
               onPress={this.snapshot("empty")}

--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -47,12 +47,12 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
 
     // Get view
     UIView *view;
-
-    if ((int)target == -1) {
+    view = viewRegistry[target];
+    BOOL nativeCapture = false;
+    if (!view) {
       UIWindow *window = [[UIApplication sharedApplication] keyWindow];
       view = window.rootViewController.view;
-    } else {
-      view = viewRegistry[target];
+      nativeCapture = true;
     }
 
     if (!view) {
@@ -102,7 +102,7 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
       scrollView.frame = CGRectMake(0, 0, scrollView.contentSize.width, scrollView.contentSize.height);
     }
 
-    if ((int)target == -1) {
+    if (nativeCapture) {
       if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)]) {
         UIGraphicsBeginImageContextWithOptions(view.window.bounds.size, NO, [UIScreen mainScreen].scale);
       } else {

--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -47,12 +47,12 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
 
     // Get view
     UIView *view;
-    view = viewRegistry[target];
-    BOOL nativeCapture = false;
-    if (!view) {
+
+    if ([target intValue] == -1) {
       UIWindow *window = [[UIApplication sharedApplication] keyWindow];
       view = window.rootViewController.view;
-      nativeCapture = true;
+    } else {
+      view = viewRegistry[target];
     }
 
     if (!view) {
@@ -102,7 +102,7 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
       scrollView.frame = CGRectMake(0, 0, scrollView.contentSize.width, scrollView.contentSize.height);
     }
 
-    if (nativeCapture) {
+    if ([target intValue] == -1) {
       if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)]) {
         UIGraphicsBeginImageContextWithOptions(view.window.bounds.size, NO, [UIScreen mainScreen].scale);
       } else {

--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -19,11 +19,11 @@ RCT_EXPORT_MODULE()
   return RCTGetUIManagerQueue();
 }
 
-RCT_EXPORT_METHOD(captureScreenshot: (NSDictionary *)options
+RCT_EXPORT_METHOD(captureScreen: (NSDictionary *)options
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) 
 {
-  [captureRef -1, options, resolve, reject];
+  [self captureRef: [NSNumber numberWithInt:-1] withOptions:options resolve:resolve reject:reject];
 }
 
 RCT_EXPORT_METHOD(releaseCapture:(nonnull NSString *)uri)
@@ -48,7 +48,7 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
     // Get view
     UIView *view;
 
-    if (target == -1) {
+    if ((int)target == -1) {
       UIWindow *window = [[UIApplication sharedApplication] keyWindow];
       view = window.rootViewController.view;
     } else {
@@ -102,11 +102,11 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
       scrollView.frame = CGRectMake(0, 0, scrollView.contentSize.width, scrollView.contentSize.height);
     }
 
-    if (target == -1) {
+    if ((int)target == -1) {
       if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)]) {
-        UIGraphicsBeginImageContextWithOptions(currentView.window.bounds.size, NO, [UIScreen mainScreen].scale);
+        UIGraphicsBeginImageContextWithOptions(view.window.bounds.size, NO, [UIScreen mainScreen].scale);
       } else {
-        UIGraphicsBeginImageContext(currentView.window.bounds.size);
+        UIGraphicsBeginImageContext(view.window.bounds.size);
       }
     } else {
       UIGraphicsBeginImageContextWithOptions(size, NO, 0);

--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -102,15 +102,7 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
       scrollView.frame = CGRectMake(0, 0, scrollView.contentSize.width, scrollView.contentSize.height);
     }
 
-    if ([target intValue] == -1) {
-      if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)]) {
-        UIGraphicsBeginImageContextWithOptions(view.window.bounds.size, NO, [UIScreen mainScreen].scale);
-      } else {
-        UIGraphicsBeginImageContext(view.window.bounds.size);
-      }
-    } else {
-      UIGraphicsBeginImageContextWithOptions(size, NO, 0);
-    }
+    UIGraphicsBeginImageContextWithOptions(size, NO, 0);
     
     success = [rendered drawViewHierarchyInRect:(CGRect){CGPointZero, size} afterScreenUpdates:YES];
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ export function captureScreen(
         errors.map(e => `- ${e}`).join("\n")
     );
   }
-  return RNViewShot.captureScreenshot(options);
+  return RNViewShot.captureScreen(options);
 }
 
 type Props = {

--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ export function releaseCapture(uri: string): void {
   }
 }
 
-export function captureScreenshot(
+export function captureScreen(
   optionsObject?: Options
 ): Promise<string> {
   const { options, errors } = validateOptions(optionsObject);

--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,19 @@ export function releaseCapture(uri: string): void {
   }
 }
 
+export function captureScreenshot(
+  optionsObject?: Options
+): Promise<string> {
+  const { options, errors } = validateOptions(optionsObject);
+  if (__DEV__ && errors.length > 0) {
+    console.warn(
+      "react-native-view-shot: bad options:\n" +
+        errors.map(e => `- ${e}`).join("\n")
+    );
+  }
+  return RNViewShot.captureScreenshot(options);
+}
+
 type Props = {
   options?: Object,
   captureMode?: "mount" | "continuous" | "update",


### PR DESCRIPTION
This PR offers to extend the functionality of the NPM package to include a generic screenshot.

On Android and iOS devices, a screenshot can be triggered by the user by pressing various hardware buttons. This screenshot captures the entire screen as the user sees it and is most likely to be what the user views as a normal "screenshot." Extending the functionality of the NPM package will allow developers the ability to provide a normal screenshot without the need of wrapping JSXElements in a new component or remembering ref values.

In addition, this solves the issue of taking a screenshot when using layered navigators, where passing child refs up to a main navigator is generally [not recommended](https://facebook.github.io/react/docs/refs-and-the-dom.html#exposing-dom-refs-to-parent-components).

This functionality will not capture an entire ScrollView or similar containers that might extend off screen. To capture those Views, the regular capture methods should still be used.