### PR TITLE
Include RCTUIManagerUtils.h for more recent RN versions

### DIFF
--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -6,6 +6,9 @@
 #import <React/RCTConvert.h>
 #import <React/RCTScrollView.h>
 #import <React/RCTUIManager.h>
+#if __has_include(<React/RCTUIManagerUtils.h>)
+#import <React/RCTUIManagerUtils.h>
+#endif
 #import <React/RCTBridge.h>
 
 @implementation RNViewShot


### PR DESCRIPTION
https://github.com/facebook/react-native/commit/6d67e2dbbcd658b7f845ebb0d0156bd64dc68226 moved `RCTGetUIManagerQueue` to `RCTUIManagerUtils.h` so we have to include it to compile. The file is imported only if it exists so this is backwards compatible.