### PR TITLE
Make onCapture & onCaptureFailure props optional in flow type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,8 +132,8 @@ type Props = {
   captureMode?: "mount" | "continuous" | "update",
   children: React.Element<*>,
   onLayout?: (e: *) => void,
-  onCapture: (uri: string) => void,
-  onCaptureFailure: (e: Error) => void
+  onCapture?: (uri: string) => void,
+  onCaptureFailure?: (e: Error) => void
 };
 
 function checkCompatibleProps(props: Props) {


### PR DESCRIPTION
I followed the following example from the README & flow is erroring for me as `onCapture` & `onCaptureFailure` are required in the `Props` flow type definition, this PR makes them optional.

```javascript
class ExampleCaptureOnMountManually extends Component {
  componentDidMount () {
    this.refs.viewShot.capture().then(uri => {
      console.log("do something with ", uri);
    });
  }
  render() {
    return (
      <ViewShot ref="viewShot" options={{ format: "jpg", quality: 0.9 }}>
        <Text>...Something to rasterize...</Text>
      </ViewShot>
    );
  }
}
```