### PR TITLE
Add check for null path in releaseCapture

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
@@ -55,7 +55,9 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void releaseCapture(String uri) {
-        File file = new File(Uri.parse(uri).getPath());
+        final String path = Uri.parse(uri).getPath();
+        if (path == null) return;
+        File file = new File(path);
         if (!file.exists()) return;
         File parent = file.getParentFile();
         if (parent.equals(reactContext.getExternalCacheDir()) || parent.equals(reactContext.getCacheDir())) {


### PR DESCRIPTION
`releaseCapture` is called when capturing with `data-uri` result, then `Uri.parse(uri).getPath()` returns `null` for the base64 `uri`, then `File constructor` throws a `NullPointerException`