### PR TITLE
Add scaleRealPixelSize property to options to scale image result pixel size to actual height/width input

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Returns a Promise of the image URI.
     - `"tmpfile"` (default): save to a temporary file *(that will only exist for as long as the app is running)*.
     - `"base64"`: encode as base64 and returns the raw string. Use only with small images as this may result of lags (the string is sent over the bridge). *N.B. This is not a data uri, use `data-uri` instead*.
     - `"data-uri"`: same as `base64` but also includes the [Data URI scheme](https://en.wikipedia.org/wiki/Data_URI_scheme) header.
+  - **`scaleRealPixelSize`** *(bool)*: if true the captured image size will be scaled so that the real pixel size will match the input width/height.
   - **`snapshotContentContainer`** *(bool)*: if true and when view is a ScrollView, the "content container" height will be evaluated instead of the container height.
 
 ## `releaseCapture(uri)`
@@ -207,7 +208,7 @@ Alternatively, you can use the `ViewShot` component that will wait the first `on
 
 ### Snapshotted image does not match my width and height but is twice/3-times bigger
 
-This is because the snapshot image result is in real pixel size where the width/height defined in a React Native style are defined in "point" unit. You might want to set width and height option to force a resize. (might affect image quality)
+This is because the snapshot image result is in real pixel size where the width/height defined in a React Native style are defined in "point" unit. You might want to set width and height option to force a resize (might affect image quality). Use the `options` property `scaleRealPixelSize` to resize the image result to the input `width`/`height` properties.
 
 
 ---

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 //@flow
 import React, { Component } from "react";
-import { View, NativeModules, Platform, findNodeHandle } from "react-native";
+import { View, NativeModules, Platform, PixelRatio, findNodeHandle } from "react-native";
 const { RNViewShot } = NativeModules;
 
 const neverEndingPromise = new Promise(() => {});
@@ -11,6 +11,7 @@ type Options = {
   format: "png" | "jpg" | "webm",
   quality: number,
   result: "tmpfile" | "base64" | "data-uri",
+  scaleRealPixelSize: boolean,
   snapshotContentContainer: boolean
 };
 
@@ -82,6 +83,22 @@ function validateOptions(
   return { options, errors };
 }
 
+//scale real pixel size dimensions to input height/width using PixelRatio
+function scaleDimensions(options?: Object
+): Object {
+  if ("scaleRealPixelSize" in options &&
+    options.scaleRealPixelSize &&
+    (typeof options.scaleRealPixelSize === "boolean")
+  ) {
+    if(options.width) {
+      options.width = options.width / PixelRatio.get();
+    }
+    if(options.height) {
+      options.height = options.height / PixelRatio.get();
+    }
+  }
+}
+
 export function captureRef(
   view: number | ReactElement<*>,
   optionsObject?: Object
@@ -95,6 +112,7 @@ export function captureRef(
     view = node;
   }
   const { options, errors } = validateOptions(optionsObject);
+  scaleDimensions(options);
   if (__DEV__ && errors.length > 0) {
     console.warn(
       "react-native-view-shot: bad options:\n" +


### PR DESCRIPTION
I have added an addition property to the `options` prop called `scaleRealPixelSize` which utilises the React-Native `PixelRatio` component to get the device's pixel density and divides the input `height`/`width` values by this value in order to get a image result that has the actual pixel height and width.  

This can be useful especially when application configuration/settings require the returned image from `react-native-view-shot` to be at a specified pixel width/height.