### PR TITLE
Fix psitioning of TextureView elements relative to target element

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -187,8 +187,8 @@ public class ViewShot implements UIBlock {
                     if (parentElem == view) {
                         break;
                     }
-                    parentLeft += parentElem.getLeft();
-                    parentTop += parentElem.getTop();
+                    left += parentElem.getLeft();
+                    top += parentElem.getTop();
                     parentElem = (View)parentElem.getParent();
                 }
                 c.drawBitmap(childBitmapBuffer, left + child.getPaddingLeft(),  top + child.getPaddingTop(), null);

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -180,7 +180,18 @@ public class ViewShot implements UIBlock {
             if(child instanceof TextureView) {
                 ((TextureView) child).setOpaque(false);
                 childBitmapBuffer = ((TextureView) child).getBitmap(child.getWidth(), child.getHeight());
-                c.drawBitmap(childBitmapBuffer, child.getLeft() + ((ViewGroup)child.getParent()).getLeft() +  child.getPaddingLeft(), child.getTop() + ((ViewGroup)child.getParent()).getTop() + child.getPaddingTop(), null);
+                int left = child.getLeft();
+                int top = child.getTop();
+                View parentElem = (View)child.getParent();
+                while (parentElem != null) {
+                    if (parentElem == view) {
+                        break;
+                    }
+                    parentLeft += parentElem.getLeft();
+                    parentTop += parentElem.getTop();
+                    parentElem = (View)parentElem.getParent();
+                }
+                c.drawBitmap(childBitmapBuffer, left + child.getPaddingLeft(),  top + child.getPaddingTop(), null);
             }
         }
 


### PR DESCRIPTION
Short fix for positioning of TextureView by iterating through parent elements until target element has been reached and getting the total of the left&top values.