### PR TITLE
close java OutputStreams before resolve Promises

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -75,8 +75,7 @@ public class ViewShot implements UIBlock {
 
     @Override
     public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
-        OutputStream os = null;
-        View view = null;
+        final View view;
 
         if (tag == -1) {
             view = currentActivity.getWindow().getDecorView().findViewById(android.R.id.content);
@@ -90,39 +89,26 @@ public class ViewShot implements UIBlock {
         }
         try {
             if ("tmpfile".equals(result)) {
-                os = new FileOutputStream(output);
-                captureView(view, os);
-                String uri = Uri.fromFile(output).toString();
+                captureView(view, new FileOutputStream(output));
+                final String uri = Uri.fromFile(output).toString();
                 promise.resolve(uri);
-            }
-            else if ("base64".equals(result)) {
-                os = new ByteArrayOutputStream();
+            } else if ("base64".equals(result)) {
+                final ByteArrayOutputStream os = new ByteArrayOutputStream();
                 captureView(view, os);
-                byte[] bytes = ((ByteArrayOutputStream) os).toByteArray();
-                String data = Base64.encodeToString(bytes, Base64.NO_WRAP);
+                final byte[] bytes = os.toByteArray();
+                final String data = Base64.encodeToString(bytes, Base64.NO_WRAP);
                 promise.resolve(data);
-            }
-            else if ("data-uri".equals(result)) {
-                os = new ByteArrayOutputStream();
+            } else if ("data-uri".equals(result)) {
+                final ByteArrayOutputStream os = new ByteArrayOutputStream();
                 captureView(view, os);
-                byte[] bytes = ((ByteArrayOutputStream) os).toByteArray();
+                final byte[] bytes = os.toByteArray();
                 String data = Base64.encodeToString(bytes, Base64.NO_WRAP);
                 data = "data:image/"+extension+";base64," + data;
                 promise.resolve(data);
             }
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
             promise.reject(ERROR_UNABLE_TO_SNAPSHOT, "Failed to capture view snapshot");
-        }
-        finally {
-            if (os != null) {
-                try {
-                    os.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
         }
     }
 
@@ -152,7 +138,15 @@ public class ViewShot implements UIBlock {
      * @param view the view to capture
      * @return the screenshot or null if it failed.
      */
-    private void captureView (View view, OutputStream os) {
+    private void captureView(View view, OutputStream os) throws IOException {
+        try {
+            captureViewImpl(view, os);
+        } finally {
+            os.close();
+        }
+    }
+
+    private void captureViewImpl(View view, OutputStream os) {
         int w = view.getWidth();
         int h = view.getHeight();
 

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -33,18 +33,18 @@ public class ViewShot implements UIBlock {
 
     static final String ERROR_UNABLE_TO_SNAPSHOT = "E_UNABLE_TO_SNAPSHOT";
 
-    private int tag;
-    private String extension;
-    private Bitmap.CompressFormat format;
-    private double quality;
-    private Integer width;
-    private Integer height;
-    private File output;
-    private String result;
-    private Promise promise;
-    private Boolean snapshotContentContainer;
-    private  ReactApplicationContext reactContext;
-    private Activity currentActivity;
+    private final int tag;
+    private final String extension;
+    private final Bitmap.CompressFormat format;
+    private final double quality;
+    private final Integer width;
+    private final Integer height;
+    private final File output;
+    private final String result;
+    private final Promise promise;
+    private final Boolean snapshotContentContainer;
+    private final ReactApplicationContext reactContext;
+    private final Activity currentActivity;
 
     public ViewShot(
             int tag,


### PR DESCRIPTION
I noticed that this code was resolving Promises before closing the OutputStreams it uses. We've not seen a failure that we could attribute to this problem, but it does look like it could at least theoretically cause JavaScript code that runs when the promise is resolved to see partially-written png files.

