### PR TITLE
Add type definitions for style prop

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,6 +10,7 @@
 
 declare module 'react-native-view-shot' {
     import { Component, ReactInstance } from 'react'
+    import { StyleObj } from 'react-native/Libraries/StyleSheet/StyleSheetTypes'
 
     export interface CaptureOptions {
         /**
@@ -66,6 +67,10 @@ declare module 'react-native-view-shot' {
          * @param {Error} error
          */
         onCaptureFailure?(error: Error): void;
+        /**
+         * style prop as StyleObj
+         */
+        style?: StyleObj;
     }
 
     export default class ViewShot extends Component<ViewShotProperties> {


### PR DESCRIPTION
The style prop was added in #131, but the type definitions were left out which makes this unusable with TypeScript.