### PR TITLE
 fixed the base64 MIME type when JPG is chosen

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -107,6 +107,10 @@ public class ViewShot implements UIBlock {
                 captureView(view, os);
                 byte[] bytes = ((ByteArrayOutputStream) os).toByteArray();
                 String data = Base64.encodeToString(bytes, Base64.NO_WRAP);
+                // correct the extension if JPG
+                if (extension != null && extension.equals("jpg")) {
+                    extension = "jpeg";
+                }
                 data = "data:image/"+extension+";base64," + data;
                 promise.resolve(data);
             }

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -108,7 +108,7 @@ public class ViewShot implements UIBlock {
                 byte[] bytes = ((ByteArrayOutputStream) os).toByteArray();
                 String data = Base64.encodeToString(bytes, Base64.NO_WRAP);
                 // correct the extension if JPG
-                if (extension != null && extension.equals("jpg")) {
+                if ("jpg".equals(extension)) {
                     extension = "jpeg";
                 }
                 data = "data:image/"+extension+";base64," + data;


### PR DESCRIPTION
valid MIME type for JPEG / JPG images is "image/jpeg" 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Image_types
This was causing Android not to recognize the screenshots taken by this library