### PR TITLE
fixed the base64 MIME type when JPG is chosen (iOS)

### DIFF
--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -148,7 +148,8 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
       else if ([result isEqualToString:@"data-uri"]) {
         // Return as a base64 data uri string
         NSString *base64 = [data base64EncodedStringWithOptions: NSDataBase64Encoding64CharacterLineLength];
-        res = [NSString stringWithFormat:@"data:image/%@;base64,%@", format, base64];
+        NSString *imageFormat = ([format isEqualToString:@"jpg"]) ? @"jpeg" : format;
+        res = [NSString stringWithFormat:@"data:image/%@;base64,%@", imageFormat, base64];
       }
       else {
         // Save to a temp file


### PR DESCRIPTION
valid MIME type for JPEG / JPG images is "image/jpeg" 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Image_types
This was causing iOS not to recognize the screenshots taken by this library