### PR TITLE
Fix index.d.ts import from react-native types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,7 +10,7 @@
 
 declare module 'react-native-view-shot' {
     import { Component, ReactInstance } from 'react'
-    import { StyleObj } from 'react-native/Libraries/StyleSheet/StyleSheetTypes'
+    import { ViewStyle } from 'react-native'
 
     export interface CaptureOptions {
         /**
@@ -69,9 +69,9 @@ declare module 'react-native-view-shot' {
          */
         onCaptureFailure?(error: Error): void;
         /**
-         * style prop as StyleObj
+         * style prop as ViewStyle
          */
-        style?: StyleObj;
+        style?: ViewStyle;
     }
 
     export default class ViewShot extends Component<ViewShotProperties> {


### PR DESCRIPTION
Currently with TypeScript and `@types/react-native`, you'll get the following error:
```
Could not find a declaration file for module 'react-native/Libraries/StyleSheet/StyleSheetTypes'.
'/myproj/node_modules/react-native/Libraries/StyleSheet/StyleSheetTypes.js' implicitly has an 'any' type.
Try `npm install @types/react-native` if it exists or add a new declaration (.d.ts) file containing `declare module 'react-native';
```

I don't know what strange version of `react-native` types whoever created the previous PR to add this `StyleObj` import was using, but it definitely wasn't the DefinitelyTyped version that most people would use.