### PR TITLE
Fix dependency incompatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,7 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 buildscript {
     /* In case of submodule usage, do not try to apply own repositories and plugins,
         root project is responsible for that. */
@@ -15,12 +19,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "28.0.3"
+    compileSdkVersion safeExtGet('compileSdkVersion', 27)
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 27
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 27)
 
         versionCode 1
         versionName "1.0"
@@ -42,7 +46,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.android.support:support-v4:27.+'
-
+    implementation "com.android.support:support-v4:${safeExtGet('supportLibVersion', '27.+')}"
     api 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Old config called `Android dependency 'com.android.support:support-v4' has different version for the compile (26.1.0) and runtime (27.1.1) classpath. You should manually set the same version via DependencyResolution` error, this PR has fixed this