### PR TITLE
[js] Add React.Ref support to captureRef

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,7 +9,7 @@
  */
 
 declare module 'react-native-view-shot' {
-    import { Component, ReactInstance } from 'react'
+    import { Component, ReactInstance, RefObject } from 'react'
     import { ViewStyle } from 'react-native'
 
     export interface CaptureOptions {
@@ -81,11 +81,11 @@ declare module 'react-native-view-shot' {
     /**
      * lower level imperative API
      *
-     * @param {React.ReactInstance} viewRef
+     * @param {React.ReactInstance | RefObject} viewRef
      * @param {"react-native-view-shot".CaptureOptions} options
      * @return {Promise<string>} Returns a Promise of the image URI.
      */
-    export function captureRef(viewRef: ReactInstance, options?: CaptureOptions): Promise<string>
+    export function captureRef<T>(viewRef: ReactInstance | RefObject<T>, options?: CaptureOptions): Promise<string>
 
     /**
      * This method release a previously captured uri. For tmpfile it will clean them out, for other result types it

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 import { View, NativeModules, Platform, findNodeHandle } from "react-native";
 const { RNViewShot } = NativeModules;
 
-import type { Element, ElementRef } from 'react';
+import type { Element, ElementRef, ElementType, Ref } from 'react';
 import type { ViewStyleProp } from 'StyleSheet';
 import type { LayoutEvent } from 'CoreEventTypes';
 
@@ -88,10 +88,13 @@ function validateOptions(
   return { options, errors };
 }
 
-export function captureRef(
-  view: number | ?View,
+export function captureRef<T: ElementType>(
+  view: number | ?View | Ref<T>,
   optionsObject?: Object
 ): Promise<string> {
+  if (view && typeof view === "object" && "current" in view && view.current) { // React.RefObject
+    view = view.current;
+  }
   if (typeof view !== "number") {
     const node = findNodeHandle(view);
     if (!node)


### PR DESCRIPTION
Ports https://github.com/expo/expo/issues/2434 to the actual `react-native-view-shot` library. 🙂 