### PR TITLE
Fix crash on android api level less than 21

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/DebugViews.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/DebugViews.java
@@ -148,13 +148,15 @@ public final class DebugViews {
                             .append("]");
                 }
             }
-
-            if (0.0f != v.getTranslationX() || 0.0f != v.getTranslationY() || 0.0f != v.getTranslationZ()) {
-                sb.append(", translate=[")
-                        .append(v.getTranslationX()).append(",")
-                        .append(v.getTranslationY()).append(",")
-                        .append(v.getTranslationZ())
-                        .append("]");
+            
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                if (0.0f != v.getTranslationX() || 0.0f != v.getTranslationY() || 0.0f != v.getTranslationZ()) {
+                    sb.append(", translate=[")
+                            .append(v.getTranslationX()).append(",")
+                            .append(v.getTranslationY()).append(",")
+                            .append(v.getTranslationZ())
+                            .append("]");
+                }
             }
 
             if (1.0f != v.getScaleX() || 1.0f != v.getScaleY()) {


### PR DESCRIPTION
Fix #237, `getTranslationZ` Added in API level 21.