### PR TITLE
type: fix for typescript (add missing type)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -81,11 +81,11 @@ declare module 'react-native-view-shot' {
     /**
      * lower level imperative API
      *
-     * @param {React.ReactInstance | RefObject} viewRef
+     * @param {number | React.ReactInstance | RefObject} viewRef
      * @param {"react-native-view-shot".CaptureOptions} options
      * @return {Promise<string>} Returns a Promise of the image URI.
      */
-    export function captureRef<T>(viewRef: ReactInstance | RefObject<T>, options?: CaptureOptions): Promise<string>
+    export function captureRef<T>(viewRef: number | ReactInstance | RefObject<T>, options?: CaptureOptions): Promise<string>
 
     /**
      * This method release a previously captured uri. For tmpfile it will clean them out, for other result types it


### PR DESCRIPTION
Add `number` to first argument of `captureRef()` as original flowtyped typing