### PR TITLE
Use 'renderInContext' to generate image

### DIFF
--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -69,9 +69,6 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
     NSString *result = [RCTConvert NSString:options[@"result"]];
     BOOL snapshotContentContainer = [RCTConvert BOOL:options[@"snapshotContentContainer"]];
 
-    // Capture image
-    BOOL success;
-
     UIView* rendered;
     UIScrollView* scrollView;
     if (snapshotContentContainer) {
@@ -106,8 +103,7 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
     }
 
     UIGraphicsBeginImageContextWithOptions(size, NO, 0);
-    
-    success = [rendered drawViewHierarchyInRect:(CGRect){CGPointZero, size} afterScreenUpdates:YES];
+    [rendered.layer renderInContext: UIGraphicsGetCurrentContext()];
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
 
@@ -115,11 +111,6 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
       // Restore scroll & frame
       scrollView.contentOffset = savedContentOffset;
       scrollView.frame = savedFrame;
-    }
-
-    if (!success) {
-      reject(RCTErrorUnspecified, @"The view cannot be captured. drawViewHierarchyInRect was not successful. This is a potential technical or security limitation.", nil);
-      return;
     }
 
     if (!image) {


### PR DESCRIPTION
* Using drawViewHierarchyInRect failed for 800 × 8235 pixels image.
* Fixes #268.

`renderInContext` is slower but proved much more reliable in my test case (generating a view I send to a receipt printer). At about 23", the image becomes blank.