### PR TITLE
Fixes issue with finding React Native version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,5 +47,5 @@ repositories {
 
 dependencies {
     implementation "com.android.support:support-v4:${safeExtGet('supportLibVersion', '27.+')}"
-    api "com.facebook.react:react-native:${rootProject.ext.reactNative}"
+    api "com.facebook.react:react-native:${safeExtGet('reactNative', '+')}"
 }


### PR DESCRIPTION
- Fixes #284 

Searching for reactNative version in projects ext root now uses safeExtGet to stop build issues where reactNative is not set.