### PR TITLE
fix: enable build in Xcode 12 (for iOS >= 12)

### DIFF
--- a/react-native-view-shot.podspec
+++ b/react-native-view-shot.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/gre/react-native-view-shot.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end
 


### PR DESCRIPTION
Updated react dependency in podspec to enable build in Xcode 12 (for iOS >= 12)
See [facebook/react-native#29633 (comment)](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116)