### PR TITLE
typescript(View): onLayout

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -69,6 +69,11 @@ declare module 'react-native-view-shot' {
          */
         onCaptureFailure?(error: Error): void;
         /**
+         * Invoked on mount and layout changes
+         * @param {LayoutEvent} event
+         */
+        onLayout?(event: LayoutEvent): void;
+        /**
          * style prop as ViewStyle
          */
         style?: ViewStyle;


### PR DESCRIPTION
Add onLayout type definition

Typescript was complaining about the onLayout prop being passed to the ViewShot component so I'm adding it to the types since it's an optional param in the usage.