### PR TITLE
[Breaking] Cleanup and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,16 +130,17 @@ Returns a Promise of the image URI.
   - **`format`** _(string)_: either `png` or `jpg` or `webm` (Android). Defaults to `png`.
   - **`quality`** _(number)_: the quality. 0.0 - 1.0 (default). (only available on lossy formats like jpg)
   - **`result`** _(string)_, the method you want to use to save the snapshot, one of:
-    - `"tmpfile"` (default): save to a temporary file _(that will only exist for as long as the app is running)_.
+    - `"file"` (default): save to a temporary file if path is not given, or to the given path.
     - `"base64"`: encode as base64 and returns the raw string. Use only with small images as this may result of lags (the string is sent over the bridge). _N.B. This is not a data uri, use `data-uri` instead_.
     - `"data-uri"`: same as `base64` but also includes the [Data URI scheme](https://en.wikipedia.org/wiki/Data_URI_scheme) header.
+  - **`path`** _(str or empty)_: if using `"file"`, this is the path the file will be saved to, or a path will be provided automatically into the cache folder. If a path is given, you are responsible of making it a valid folder and using a valid file name and extension.
   - **`snapshotContentContainer`** _(bool)_: if true and when view is a ScrollView, the "content container" height will be evaluated instead of the container height.
+
 
 ## `releaseCapture(uri)`
 
-This method release a previously captured `uri`. For tmpfile it will clean them out, for other result types it just won't do anything.
+This method release a previously captured `uri`.
 
-NB: the tmpfile captures are automatically cleaned out after the app closes, so you might not have to worry about this unless advanced usecases. The `ViewShot` component will use it each time you capture more than once (useful for continuous capture to not leak files).
 
 ## `captureScreen()` Android and iOS Only
 
@@ -213,7 +214,7 @@ Advantages:
 
 - no compression, so its supper quick. Screenshot taking is less than 16ms;
 
-RAW format supported for `zip-base64`, `base64` and `tmpfile` result types.
+RAW format supported for `zip-base64`, `base64` and `file` result types.
 
 RAW file on disk saved in format: `${width}:${height}|${base64}` string.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,10 +8,10 @@ buildscript {
     if (rootProject.buildDir == project.buildDir) {
         repositories {
             google()
-            jcenter()
+            mavenCentral()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath 'com.android.tools.build:gradle:4.2.2'
         }
     }
 }
@@ -20,14 +20,15 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
-    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
+
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_1_8
+      targetCompatibility JavaVersion.VERSION_1_8
+    }
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 28)
-
-        versionCode 1
-        versionName "1.0"
     }
 
     lintOptions {
@@ -36,16 +37,15 @@ android {
 }
 
 repositories {
-    google()
-    jcenter()
-    mavenLocal()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$rootDir/../node_modules/react-native/android"
     }
+    google()
+    mavenLocal()
+    mavenCentral()
 }
 
 dependencies {
-    implementation "com.android.support:support-v4:${safeExtGet('supportLibVersion', '27.+')}"
     api "com.facebook.react:react-native:${safeExtGet('reactNative', '+')}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,51 +1,28 @@
+def DEFAULT_COMPILE_SDK_VERSION = 29
+def DEFAULT_TARGET_SDK_VERSION = 29
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
-buildscript {
-    /* In case of submodule usage, do not try to apply own repositories and plugins,
-        root project is responsible for that. */
-    if (rootProject.buildDir == project.buildDir) {
-        repositories {
-            google()
-            mavenCentral()
-        }
-        dependencies {
-            classpath 'com.android.tools.build:gradle:4.2.2'
-        }
-    }
-}
-
 apply plugin: 'com.android.library'
 
-android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
-    compileOptions {
-      sourceCompatibility JavaVersion.VERSION_1_8
-      targetCompatibility JavaVersion.VERSION_1_8
-    }
+android {
+    compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 28)
-    }
-
-    lintOptions {
-        abortOnError false
+        targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
+        versionCode 1
+        versionName "1.0"
     }
 }
 
-repositories {
-    maven {
-        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "$rootDir/../node_modules/react-native/android"
-    }
-    google()
-    mavenLocal()
+repositories{
     mavenCentral()
 }
 
 dependencies {
-    api "com.facebook.react:react-native:${safeExtGet('reactNative', '+')}"
+    implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
 }

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotPackage.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotPackage.java
@@ -9,17 +9,11 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
-import com.facebook.react.bridge.JavaScriptModule;
+
 public class RNViewShotPackage implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-      return Arrays.<NativeModule>asList(new RNViewShotModule(reactContext));
-    }
-
-    // Deprecated RN 0.47
-    // @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
+      return Arrays.asList(new RNViewShotModule(reactContext));
     }
 
     @Override

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -84,12 +84,12 @@ public class ViewShot implements UIBlock {
     /**
      * Supported Output results.
      */
-    @StringDef({Results.BASE_64, Results.DATA_URI, Results.TEMP_FILE, Results.ZIP_BASE_64})
+    @StringDef({Results.BASE_64, Results.DATA_URI, Results.FILE, Results.ZIP_BASE_64})
     public @interface Results {
         /**
-         * Save screenshot as temp file on device.
+         * Save screenshot as file on device.
          */
-        String TEMP_FILE = "tmpfile";
+        String FILE = "file";
         /**
          * Base 64 encoded image.
          */
@@ -182,10 +182,10 @@ public class ViewShot implements UIBlock {
             stream.setSize(proposeSize(view));
             outputBuffer = stream.innerBuffer();
 
-            if (Results.TEMP_FILE.equals(result) && Formats.RAW == this.format) {
+            if (Results.FILE.equals(result) && Formats.RAW == this.format) {
                 saveToRawFileOnDevice(view);
-            } else if (Results.TEMP_FILE.equals(result) && Formats.RAW != this.format) {
-                saveToTempFileOnDevice(view);
+            } else if (Results.FILE.equals(result) && Formats.RAW != this.format) {
+                saveToFileOnDevice(view);
             } else if (Results.BASE_64.equals(result) || Results.ZIP_BASE_64.equals(result)) {
                 saveToBase64String(view);
             } else if (Results.DATA_URI.equals(result)) {
@@ -199,7 +199,7 @@ public class ViewShot implements UIBlock {
     //endregion
 
     //region Implementation
-    private void saveToTempFileOnDevice(@NonNull final View view) throws IOException {
+    private void saveToFileOnDevice(@NonNull final View view) throws IOException {
         final FileOutputStream fos = new FileOutputStream(output);
         captureView(view, fos);
 
@@ -301,7 +301,7 @@ public class ViewShot implements UIBlock {
      */
     private Point captureView(@NonNull final View view, @NonNull final OutputStream os) throws IOException {
         try {
-            DebugViews.longDebug(TAG, DebugViews.logViewHierarchy(this.currentActivity));
+            //DebugViews.longDebug(TAG, DebugViews.logViewHierarchy(this.currentActivity));
 
             return captureViewImpl(view, os);
         } finally {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -195,10 +195,10 @@ PODS:
     - react-native-video/Video (= 5.0.2)
   - react-native-video/Video (5.0.2):
     - React
-  - react-native-view-shot (3.1.0):
-    - React
-  - react-native-webview (8.0.4):
-    - React
+  - react-native-view-shot (3.2.0):
+    - React-Core
+  - react-native-webview (11.0.0):
+    - React-Core
   - React-RCTActionSheet (0.61.5):
     - React-Core/RCTActionSheetHeaders (= 0.61.5)
   - React-RCTAnimation (0.61.5):
@@ -400,8 +400,8 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 25260c5d0b9c53fd7aa88e569e2edae72af1f6a3
   react-native-slider: 3a1cfd00c9c31068251b536822f7192e8d1d6b6f
   react-native-video: d01ed7ff1e38fa7dcc6c15c94cf505e661b7bfd0
-  react-native-view-shot: 5736211754701bfc77e170eaf65b81f893765690
-  react-native-webview: 3f5aa91c3cb083ea4762e006b9653291a96a777a
+  react-native-view-shot: 13c8b573ddabb459be38113caa7ef26758a89e10
+  react-native-webview: 6b7950628616679d81bdd75747e50cf6de9b5a5f
   React-RCTActionSheet: 600b4d10e3aea0913b5a92256d2719c0cdd26d76
   React-RCTAnimation: 791a87558389c80908ed06cc5dfc5e7920dfa360
   React-RCTBlob: d89293cc0236d9cb0933d85e430b0bbe81ad1d72
@@ -423,4 +423,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 84c98ecc8bac59bc76ca032416b11b0e4630ff47
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.11.2

--- a/example/package.json
+++ b/example/package.json
@@ -28,7 +28,7 @@
     "react-native-svg": "^11.0.1",
     "react-native-svg-uri": "^1.2.3",
     "react-native-video": "^5.0.2",
-    "react-native-view-shot": "^3.1.1",
+    "react-native-view-shot": "^3.2.0",
     "react-native-webview": "^11.0.0",
     "react-navigation": "^4.0.10",
     "react-navigation-stack": "^2.0.15"

--- a/example/src/Full.js
+++ b/example/src/Full.js
@@ -69,7 +69,7 @@ const App = () => {
   const [config, setConfig] = useState({
     format: 'png',
     quality: 0.9,
-    result: 'tmpfile',
+    result: 'file',
     snapshotContentContainer: false,
   });
 
@@ -103,7 +103,7 @@ const App = () => {
     ref => {
       (ref ? captureRef(ref, config) : captureScreen(config))
         .then(res =>
-          config.result !== 'tmpfile'
+          config.result !== 'file'
             ? res
             : new Promise((success, failure) =>
                 // just a test to ensure res can be used in Image.getSize
@@ -241,7 +241,7 @@ const App = () => {
                 selectedValue={config.result}
                 onValueChange={r => setConfig({ ...config, result: r })}
               >
-                <Picker.Item label="tmpfile" value="tmpfile" />
+                <Picker.Item label="file" value="file" />
                 <Picker.Item label="base64" value="base64" />
                 <Picker.Item label="zip-base64 (Android Only)" value="zip-base64" />
                 <Picker.Item label="data URI" value="data-uri" />

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4622,10 +4622,9 @@ react-native-video@^5.0.2:
     prop-types "^15.5.10"
     shaka-player "^2.4.4"
 
-react-native-view-shot@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.1.1.tgz#d21ed5414c696f7bfd7544f81eab6a430d6d68f9"
-  integrity sha512-Wx/bxvmcpoqX5u/CTK6PDQoU2Oq8zYdPx9o076Btq7SGHLAhlD6TBNQYG/sWIZ+GualHSbfJHRkWLGLh9pfS9w==
+"react-native-view-shot@github:cristianoccazinsp/react-native-view-shot#c244f176eaafe02d08e821772678c24a85e93e4f":
+  version "3.2.0"
+  resolved "https://codeload.github.com/cristianoccazinsp/react-native-view-shot/tar.gz/c244f176eaafe02d08e821772678c24a85e93e4f"
 
 react-native-webview@^11.0.0:
   version "11.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-view-shot",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Capture a React Native view to an image",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-view-shot",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Capture a React Native view to an image",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,13 +32,15 @@ declare module 'react-native-view-shot' {
         quality?: number;
         /**
          * the method you want to use to save the snapshot, one of:
-         " - tmpfile" (default): save to a temporary file (that will only exist for as long as the app is running).
-         " - base64": encode as base64 and returns the raw string. Use only with small images as this may result of
+         " - file (default): save to a file (temporary or the one provided in `path`).
+         " - base64: encode as base64 and returns the raw string. Use only with small images as this may result of
          *   lags (the string is sent over the bridge). N.B. This is not a data uri, use data-uri instead.
-         " - data-uri": same as base64 but also includes the Data URI scheme header.
+         " - data-uri: same as base64 but also includes the Data URI scheme header.
          " - zip-base64: compress data with zip deflate algorithm and than convert to base64 and return as a raw string."
          */
-        result?: 'tmpfile' | 'base64' | 'data-uri' | 'zip-base64';
+        result?: 'file' | 'base64' | 'data-uri' | 'zip-base64';
+        /** The path to save the file to if using `file` */
+        path?: string,
         /**
          * if true and when view is a ScrollView, the "content container" height will be evaluated instead of the
          * container height.
@@ -88,12 +90,7 @@ declare module 'react-native-view-shot' {
     export function captureRef<T>(viewRef: number | ReactInstance | RefObject<T>, options?: CaptureOptions): Promise<string>
 
     /**
-     * This method release a previously captured uri. For tmpfile it will clean them out, for other result types it
-     * just won't do anything.
-     *
-     * NB: the tmpfile captures are automatically cleaned out after the app closes, so you might not have to worry
-     *  about this unless advanced usecases. The ViewShot component will use it each time you capture more than once
-     * (useful for continuous capture to not leak files).
+     * This method release a previously captured uri.
      * @param {string} uri
      */
     export function releaseCapture(uri: string): void

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,8 @@ type Options = {
   height?: number,
   format: "png" | "jpg" | "webm" | "raw",
   quality: number,
-  result: "tmpfile" | "base64" | "data-uri" | "zip-base64",
+  result: "file" | "base64" | "data-uri" | "zip-base64",
+  path?: string,
   snapshotContentContainer: boolean
 };
 
@@ -26,14 +27,15 @@ const acceptedFormats = ["png", "jpg"].concat(
   Platform.OS === "android" ? ["webm", "raw"] : []
 );
 
-const acceptedResults = ["tmpfile", "base64", "data-uri"].concat(
+const acceptedResults = ["file", "base64", "data-uri"].concat(
   Platform.OS === "android" ? ["zip-base64"] : []
 );
 
 const defaultOptions = {
   format: "png",
   quality: 1,
-  result: "tmpfile",
+  result: "file",
+  path: "",
   snapshotContentContainer: false
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -182,10 +182,10 @@ function checkCompatibleProps(props: Props) {
     (props.captureMode === "continuous" || props.captureMode === "update") &&
     props.options &&
     props.options.result &&
-    props.options.result !== "tmpfile"
+    props.options.result !== "file"
   ) {
     console.warn(
-      "react-native-view-shot: result=tmpfile is recommended for captureMode=" +
+      "react-native-view-shot: result=file is recommended for captureMode=" +
         props.captureMode
     );
   }

--- a/windows/RNViewShot/RNViewShotModule.cs
+++ b/windows/RNViewShot/RNViewShotModule.cs
@@ -33,7 +33,7 @@ namespace RNViewShot
             double quality = options["quality"].IsNull ? 1.0 : options["quality"].AsDouble();
             int width = options["width"].IsNull ? 0 : options["width"].AsInt16();
             int height = options["height"].IsNull ? 0 : options["height"].AsInt16();
-            string result = options["result"].IsNull ? "tmpfile" : options["result"].AsString();
+            string result = options["result"].IsNull ? "file" : options["result"].AsString();
             string path = options["path"].IsNull ? null : options["path"].AsString();
 
             if (format != "png" && format != "jpg" && format != "jpeg")

--- a/windows/RNViewShot/ViewShot.cs
+++ b/windows/RNViewShot/ViewShot.cs
@@ -39,7 +39,7 @@ namespace RNViewShot
 
             try
             {
-                if ("tmpfile" == result)
+                if ("file" == result)
                 {
                     using (var ras = new InMemoryRandomAccessStream())
                     {
@@ -121,7 +121,7 @@ namespace RNViewShot
                 (uint)targetBitmap.PixelHeight,
                 displayInformation.LogicalDpi,
                 displayInformation.LogicalDpi,
-                pixelBuffer.ToArray());                
+                pixelBuffer.ToArray());
 
 
             if (width != null && height != null && (width != w || height != h))
@@ -137,13 +137,13 @@ namespace RNViewShot
 
             await encoder.FlushAsync();
 
-            return encoder;            
+            return encoder;
         }
 
         private async Task<StorageFile> GetStorageFile()
         {
             var storageFolder = ApplicationData.Current.LocalFolder;
-            var fileName = !string.IsNullOrEmpty(path) ? path : Path.ChangeExtension(Guid.NewGuid().ToString(), extension);                
+            var fileName = !string.IsNullOrEmpty(path) ? path : Path.ChangeExtension(Guid.NewGuid().ToString(), extension);
             return await storageFolder.CreateFileAsync(fileName, CreationCollisionOption.ReplaceExisting);
         }
     }


### PR DESCRIPTION
Hello,

I've done a bunch of cleanups and improvements, not sure if you are accepting PRs or not, or even if you are still maintaining this library.  Most changes are for personal use so there are some breaking changes, but I believe that these changes make the library much more flexible and better.

Changes summary is as follows:

- Overall code cleanup (remove deprecated dependencies, bump others, etc., mostly internal stuff like removing jcenter and bumping gradle)
- Allow saving to a specific file. Result `tmpfile` is now replaced with `file`, and a new `path` option is also implemented. When using `file` and an empty/not given `path`, it is stored in a temp file as before, otherwise, it is stored in the given path.
- Do not auto cleanup the cache folder. This was actually really bad (and Android only), you were pretty much pruning the entire folder, which is not great since other libraries or parts of the code could be using it.  You may still use `releaseCapture` to do cleanup, or another file system library (e.g., expo or react-native-blob-util, these are very common and present in pretty much every RN project).
- Improve Android code so the main thread is not blocked for too long
- Get rid of all nested canvas and surface rendering. This was not too bad, but is extremely slow, cannot be computed on a background thread, and was Android only (iOS does not render none of these). Removing this, makes it much faster and makes it behave similar to iOS.  In the future, this could be a setting.