### PR TITLE
Fixes captureScreen on iOS

### DIFF
--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -53,7 +53,7 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
 
     if ([target intValue] == -1) {
       UIWindow *window = [[UIApplication sharedApplication] keyWindow];
-      view = window.rootViewController.view;
+      view = window;
     } else {
       view = viewRegistry[target];
     }


### PR DESCRIPTION
I left this as a comment on #308 but I thought I would open a pull request too.

This PR fixes a problem where `captureScreen` would not capture the entire screen on iOS. The cause of the bug is that we were capturing the window's `rootViewController`'s `view`, which might neglect any modals that were presented. The window itself _is_ a `UIView` subclass, and in native iOS implementations of this kind of feature, we typically capture the entire window contents. Otherwise, we need to walk up the view controller hierarchy to find the "top most" view controller, and it gets messy.

I've tested this locally and it works 👍 

Let me know what I can clarify here, and thanks for the library 🙌 

Fixes #308.