### PR TITLE
Fixes #291: Android: width/height options are absolute dimensions

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
@@ -81,8 +81,8 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
                 : Formats.PNG;
 
         final double quality = options.getDouble("quality");
-        final Integer scaleWidth = options.hasKey("width") ? (int) (dm.density * options.getDouble("width")) : null;
-        final Integer scaleHeight = options.hasKey("height") ? (int) (dm.density * options.getDouble("height")) : null;
+        final Integer scaleWidth = options.hasKey("width") ? options.getInt("width") : null;
+        final Integer scaleHeight = options.hasKey("height") ? options.getInt("height") : null;
         final String resultStreamFormat = options.getString("result");
         final String fileName = options.hasKey("fileName") ? options.getString("fileName") : null;
         final Boolean snapshotContentContainer = options.getBoolean("snapshotContentContainer");


### PR DESCRIPTION
A mistake was introduced on Android, on the width and height optional parameters. The provided number should control the resize of the image in absolute dimensions, regardless of the pixel ratio of the phone.

Fixes https://github.com/gre/react-native-view-shot/issues/291
Fixes https://github.com/gre/react-native-view-shot/issues/361

