### PR TITLE
Support capture SurfaceView on Android

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
@@ -86,6 +86,7 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
         final String resultStreamFormat = options.getString("result");
         final String fileName = options.hasKey("fileName") ? options.getString("fileName") : null;
         final Boolean snapshotContentContainer = options.getBoolean("snapshotContentContainer");
+        final boolean handleGLSurfaceView = options.hasKey("handleGLSurfaceViewOnAndroid") && options.getBoolean("handleGLSurfaceViewOnAndroid");
 
         try {
             File outputFile = null;
@@ -99,7 +100,7 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
             uiManager.addUIBlock(new ViewShot(
                     tag, extension, imageFormat, quality,
                     scaleWidth, scaleHeight, outputFile, resultStreamFormat,
-                    snapshotContentContainer, reactContext, activity, promise)
+                    snapshotContentContainer, reactContext, activity, handleGLSurfaceView, promise)
             );
         } catch (final Throwable ex) {
             Log.e(RNVIEW_SHOT, "Failed to snapshot view tag " + tag, ex);

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -8,7 +8,8 @@ import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Point;
 import android.net.Uri;
-
+import android.os.Build;
+import android.os.Handler;
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringDef;
@@ -18,6 +19,8 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.util.Base64;
 import android.util.Log;
+import android.view.PixelCopy;
+import android.view.SurfaceView;
 import android.view.TextureView;
 import android.view.View;
 import android.view.ViewGroup;
@@ -44,6 +47,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.Deflater;
 
 import javax.annotation.Nullable;
@@ -74,6 +79,7 @@ public class ViewShot implements UIBlock, LifecycleEventListener {
 
     private HandlerThread mBgThread;
     private Handler mBgHandler;
+    private static final int SURFACE_VIEW_READ_PIXELS_TIMEOUT = 5;
 
     @Override
     public void onHostResume() {
@@ -157,6 +163,7 @@ public class ViewShot implements UIBlock, LifecycleEventListener {
     private final Boolean snapshotContentContainer;
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private final ReactApplicationContext reactContext;
+    private final boolean handleGLSurfaceView;
     private final Activity currentActivity;
     //endregion
 
@@ -174,6 +181,7 @@ public class ViewShot implements UIBlock, LifecycleEventListener {
             final Boolean snapshotContentContainer,
             final ReactApplicationContext reactContext,
             final Activity currentActivity,
+            final boolean handleGLSurfaceView,
             final Promise promise) {
         this.tag = tag;
         this.extension = extension;
@@ -186,6 +194,7 @@ public class ViewShot implements UIBlock, LifecycleEventListener {
         this.snapshotContentContainer = snapshotContentContainer;
         this.reactContext = reactContext;
         this.currentActivity = currentActivity;
+        this.handleGLSurfaceView = handleGLSurfaceView;
         this.promise = promise;
 
         reactContext.addLifecycleEventListener(this);
@@ -405,26 +414,50 @@ public class ViewShot implements UIBlock, LifecycleEventListener {
 
         for (final View child : childrenList) {
             // skip any child that we don't know how to process
-            if (!(child instanceof TextureView)) continue;
+            if (child instanceof TextureView) {
+                // skip all invisible to user child views
+                if (child.getVisibility() != VISIBLE) continue;
 
-            // skip all invisible to user child views
-            if (child.getVisibility() != VISIBLE) continue;
+                final TextureView tvChild = (TextureView) child;
+                tvChild.setOpaque(false); // <-- switch off background fill
 
-            final TextureView tvChild = (TextureView) child;
-            tvChild.setOpaque(false); // <-- switch off background fill
+                // NOTE (olku): get re-usable bitmap. TextureView should use bitmaps with matching size,
+                // otherwise content of the TextureView will be scaled to provided bitmap dimensions
+                final Bitmap childBitmapBuffer = tvChild.getBitmap(getExactBitmapForScreenshot(child.getWidth(), child.getHeight()));
 
-            // NOTE (olku): get re-usable bitmap. TextureView should use bitmaps with matching size,
-            // otherwise content of the TextureView will be scaled to provided bitmap dimensions
-            final Bitmap childBitmapBuffer = tvChild.getBitmap(getExactBitmapForScreenshot(child.getWidth(), child.getHeight()));
+                final int countCanvasSave = c.save();
+                applyTransformations(c, view, child);
 
-            final int countCanvasSave = c.save();
-            applyTransformations(c, view, child);
+                // due to re-use of bitmaps for screenshot, we can get bitmap that is bigger in size than requested
+                c.drawBitmap(childBitmapBuffer, 0, 0, paint);
 
-            // due to re-use of bitmaps for screenshot, we can get bitmap that is bigger in size than requested
-            c.drawBitmap(childBitmapBuffer, 0, 0, paint);
+                c.restoreToCount(countCanvasSave);
+                recycleBitmap(childBitmapBuffer);
+            } else if (child instanceof SurfaceView && handleGLSurfaceView) {
+                final SurfaceView svChild = (SurfaceView)child;
+                final CountDownLatch latch = new CountDownLatch(1);
 
-            c.restoreToCount(countCanvasSave);
-            recycleBitmap(childBitmapBuffer);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    try {
+                        PixelCopy.request(svChild, bitmap, new PixelCopy.OnPixelCopyFinishedListener() {
+
+                            @Override
+                            public void onPixelCopyFinished(int copyResult) {
+                                latch.countDown();
+                            }
+                        }, new Handler());
+
+                        latch.await(SURFACE_VIEW_READ_PIXELS_TIMEOUT, TimeUnit.SECONDS);
+                    } catch (Exception e) {
+                        Log.e(TAG, "Cannot PixelCopy for " + svChild, e);
+                    }
+                } else {
+                    Bitmap cache = svChild.getDrawingCache();
+                    if (cache != null) {
+                        c.drawBitmap(svChild.getDrawingCache(), 0, 0, paint);
+                    }
+                }
+            }
         }
 
         if (width != null && height != null && (width != w || height != h)) {

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -416,11 +416,6 @@ public class ViewShot implements UIBlock, LifecycleEventListener {
         //after view is drawn, go through children
         final List<View> childrenList = getAllChildren(view);
 
-        int[] point = new int[2];
-        view.getLocationInWindow(point);
-        final int rootX = point[0];
-        final int rootY = point[1];
-
         for (final View child : childrenList) {
             // skip any child that we don't know how to process
             if (child instanceof TextureView) {
@@ -452,9 +447,10 @@ public class ViewShot implements UIBlock, LifecycleEventListener {
                         PixelCopy.request(svChild, childBitmapBuffer, new PixelCopy.OnPixelCopyFinishedListener() {
                             @Override
                             public void onPixelCopyFinished(int copyResult) {
-                                int[] childPoint = new int[2];
-                                svChild.getLocationInWindow(childPoint);
-                                c.drawBitmap(childBitmapBuffer, childPoint[0] - rootX, childPoint[1] - rootY, paint);
+                                final int countCanvasSave = c.save();
+                                applyTransformations(c, view, child);
+                                c.drawBitmap(childBitmapBuffer, 0, 0, paint);
+                                c.restoreToCount(countCanvasSave);
                                 recycleBitmap(childBitmapBuffer);
                                 latch.countDown();
                             }

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -17,6 +17,7 @@ import androidx.annotation.StringDef;
 import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
+import android.os.Looper;
 import android.util.Base64;
 import android.util.Log;
 import android.view.PixelCopy;
@@ -445,7 +446,7 @@ public class ViewShot implements UIBlock, LifecycleEventListener {
                             public void onPixelCopyFinished(int copyResult) {
                                 latch.countDown();
                             }
-                        }, new Handler());
+                        }, new Handler(Looper.getMainLooper()));
 
                         latch.await(SURFACE_VIEW_READ_PIXELS_TIMEOUT, TimeUnit.SECONDS);
                     } catch (Exception e) {

--- a/example/Example/ios/Example.xcodeproj/project.pbxproj
+++ b/example/Example/ios/Example.xcodeproj/project.pbxproj
@@ -8,11 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* ExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* ExampleTests.m */; };
-		0C80B921A6F3F58F76C31292 /* libPods-Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DCACB8F33CDC322A6C60F78 /* libPods-Example.a */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		7699B88040F8A987B510C191 /* libPods-Example-ExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-Example-ExampleTests.a */; };
+		18B88FE9BEF1140FF52CCEC0 /* libPods-Example-ExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 169C542F436F5321740B320E /* libPods-Example-ExampleTests.a */; };
+		5988C3FBC6135EB858E1BD70 /* libPods-Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7AEBA4E17C14A4CB566F0E2B /* libPods-Example.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
@@ -36,11 +36,11 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Example/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Example/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Example/main.m; sourceTree = "<group>"; };
-		19F6CBCC0A4E27FBF8BF4A61 /* libPods-Example-ExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example-ExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		169C542F436F5321740B320E /* libPods-Example-ExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example-ExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B4392A12AC88292D35C810B /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-Example-ExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-ExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-Example-ExampleTests/Pods-Example-ExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
-		5DCACB8F33CDC322A6C60F78 /* libPods-Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7AEBA4E17C14A4CB566F0E2B /* libPods-Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = Example/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		89C6BE57DB24E9ADA2F236DE /* Pods-Example-ExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-ExampleTests.release.xcconfig"; path = "Target Support Files/Pods-Example-ExampleTests/Pods-Example-ExampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
@@ -51,7 +51,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7699B88040F8A987B510C191 /* libPods-Example-ExampleTests.a in Frameworks */,
+				18B88FE9BEF1140FF52CCEC0 /* libPods-Example-ExampleTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -59,7 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0C80B921A6F3F58F76C31292 /* libPods-Example.a in Frameworks */,
+				5988C3FBC6135EB858E1BD70 /* libPods-Example.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,8 +100,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				5DCACB8F33CDC322A6C60F78 /* libPods-Example.a */,
-				19F6CBCC0A4E27FBF8BF4A61 /* libPods-Example-ExampleTests.a */,
+				7AEBA4E17C14A4CB566F0E2B /* libPods-Example.a */,
+				169C542F436F5321740B320E /* libPods-Example-ExampleTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/example/Example/ios/Podfile.lock
+++ b/example/Example/ios/Podfile.lock
@@ -75,6 +75,9 @@ PODS:
   - glog (0.3.5)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
+  - PromisesObjC (2.1.1)
+  - PromisesSwift (2.1.1):
+    - PromisesObjC (= 2.1.1)
   - RCT-Folly (2021.06.28.00-v2):
     - boost
     - DoubleConversion
@@ -292,10 +295,11 @@ PODS:
     - ReactCommon/turbomodule/core
   - react-native-slider (4.2.2):
     - React-Core
-  - react-native-video (5.2.0):
+  - react-native-video (6.0.0-alpha.1):
     - React-Core
-    - react-native-video/Video (= 5.2.0)
-  - react-native-video/Video (5.2.0):
+    - react-native-video/Video (= 6.0.0-alpha.1)
+  - react-native-video/Video (6.0.0-alpha.1):
+    - PromisesSwift
     - React-Core
   - react-native-view-shot (3.3.0-next.0):
     - React-Core
@@ -499,6 +503,8 @@ SPEC REPOS:
     - fmt
     - libevent
     - OpenSSL-Universal
+    - PromisesObjC
+    - PromisesSwift
     - SocketRocket
     - YogaKit
 
@@ -613,6 +619,8 @@ SPEC CHECKSUMS:
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
+  PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
+  PromisesSwift: 99fddfe4a0ec88a56486644c0da106694c92a604
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 3e917ea5377751094f38145fdece525aa90545a0
   RCTTypeSafety: c43c072a4bd60feb49a9570b0517892b4305c45e
@@ -629,7 +637,7 @@ SPEC CHECKSUMS:
   react-native-maps: 8b8bfada2c86205a7f5a07dd1f92f29b33ea83aa
   react-native-safe-area-context: ebf8c413eb8b5f7c392a036a315eb7b46b96845f
   react-native-slider: 2f25c919f1dc309b90e2cc8346b8042ecec2102f
-  react-native-video: a4c2635d0802f983594b7057e1bce8f442f0ad28
+  react-native-video: bb6f12a7198db53b261fefb5d609dc77417acc8b
   react-native-view-shot: 47106be5202c2554b4f106845616a8a158aae614
   react-native-webview: 8ec7ddf9eb4ddcd92b32cee7907efec19a9ec7cb
   React-perflogger: a18b4f0bd933b8b24ecf9f3c54f9bf65180f3fe6

--- a/example/Example/package.json
+++ b/example/Example/package.json
@@ -29,7 +29,7 @@
     "react-native-screens": "^3.13.1",
     "react-native-svg": "^12.3.0",
     "react-native-svg-uri": "^1.2.3",
-    "react-native-video": "^5.2.0",
+    "react-native-video": "^6.0.0-alpha.1",
     "react-native-view-shot": "^3.3.0-next.0",
     "react-native-webview": "^11.18.2"
   },

--- a/example/Example/src/Full.js
+++ b/example/Example/src/Full.js
@@ -37,6 +37,7 @@ const App = () => {
   const mapViewRef = useRef();
   const webviewRef = useRef();
   const videoRef = useRef();
+  const videoSurfaceRef = useRef();
   const transformParentRef = useRef();
   const transformRef = useRef();
   const surfaceRef = useRef();
@@ -82,8 +83,9 @@ const App = () => {
   }, []);
 
   const capture = useCallback(
-    ref => {
-      (ref ? captureRef(ref, config) : captureScreen(config))
+    (ref, options = {}) => {
+      const opts = {...config, ...options};
+      (ref ? captureRef(ref, opts) : captureScreen(opts))
         .then(res =>
           config.result !== 'file'
             ? res
@@ -159,6 +161,12 @@ const App = () => {
               <Btn label="📷 MapView" onPress={() => capture(mapViewRef)} />
               <Btn label="📷 WebView" onPress={() => capture(webviewRef)} />
               <Btn label="📷 Video" onPress={() => capture(videoRef)} />
+              <Btn
+                label="📷 Video with SurfaceView (Android)"
+                onPress={() =>
+                  capture(videoRef, {handleGLSurfaceViewOnAndroid: true})
+                }
+              />
               <Btn label="📷 Native Screenshot" onPress={() => capture()} />
               <Btn
                 label="📷 Empty View (should crash)"
@@ -326,10 +334,20 @@ const App = () => {
             </View>
             <Video
               ref={videoRef}
+              disableFocus // NOTE: https://github.com/react-native-video/react-native-video/issues/2666
               style={{width: 300, height: 300}}
               source={require('./broadchurch.mp4')}
               volume={0}
               repeat
+            />
+            <Video
+              ref={videoSurfaceRef}
+              disableFocus // NOTE: https://github.com/react-native-video/react-native-video/issues/2666
+              style={{width: 300, height: 300}}
+              source={require('./broadchurch.mp4')}
+              volume={0}
+              repeat
+              useTextureView={false} // Use SurfaceView
             />
           </View>
         </ScrollView>

--- a/example/Example/src/Video.js
+++ b/example/Example/src/Video.js
@@ -1,24 +1,47 @@
 //@flow
-import React, { useState, useCallback } from 'react';
-import { SafeAreaView, Image } from 'react-native';
+import React, {useState, useCallback} from 'react';
+import {SafeAreaView, Image} from 'react-native';
 import ViewShot from 'react-native-view-shot';
 import Video from 'react-native-video';
 import Desc from './Desc';
 
-const dimension = { width: 300, height: 300 };
+const sample = require('./broadchurch.mp4');
 
 const VideoExample = () => {
   const [source, setSource] = useState(null);
-  const onCapture = useCallback(uri => setSource({ uri }), []);
+  const onCapture = useCallback(uri => setSource({uri}), []);
   return (
     <SafeAreaView>
-      <ViewShot onCapture={onCapture} captureMode="continuous" style={dimension}>
-        <Video style={dimension} source={require('./broadchurch.mp4')} volume={0} repeat />
+      <ViewShot
+        options={{handleGLSurfaceViewOnAndroid: true}}
+        onCapture={onCapture}
+        captureMode="continuous">
+        <Video
+          disableFocus // NOTE: https://github.com/react-native-video/react-native-video/issues/2666
+          style={{width: 180, height: 90}}
+          source={sample}
+          volume={0}
+          repeat
+          resizeMode="cover"
+        />
+        <Video
+          disableFocus // NOTE: https://github.com/react-native-video/react-native-video/issues/2666
+          style={{width: 180, height: 90}}
+          source={sample}
+          volume={0}
+          repeat
+          resizeMode="cover"
+          useTextureView={false} // Use SurfaceView
+        />
       </ViewShot>
 
       <Desc desc="above is a video and below is a continuous screenshot of it" />
 
-      <Image fadeDuration={0} source={source} style={dimension} />
+      <Image
+        fadeDuration={0}
+        source={source}
+        style={{width: '100%', height: 196}}
+      />
     </SafeAreaView>
   );
 };

--- a/example/Example/yarn.lock
+++ b/example/Example/yarn.lock
@@ -2588,7 +2588,7 @@ depd@2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-deprecated-react-native-prop-types@^2.3.0:
+deprecated-react-native-prop-types@^2.2.0, deprecated-react-native-prop-types@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-2.3.0.tgz#c10c6ee75ff2b6de94bb127f142b814e6e08d9ab"
   integrity sha512-pWD0voFtNYxrVqvBMYf5gq3NA2GCpfodS1yNynTPc93AYA/KEMGeWDqqeUB6R2Z9ZofVhks2aeJXiuQqKNpesA==
@@ -2673,10 +2673,10 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.138.tgz#3ec41ca589aaf505dfe2034fde913329af801730"
   integrity sha512-IOyp2Seq3w4QLln+yZWcMF3VXhhduz4bwg9gfI+CnP5TkzwNXQ8FCZuwwPsnes73AfWdf5J2n2OXdUwDUspDPQ==
 
-eme-encryption-scheme-polyfill@^2.0.1:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/eme-encryption-scheme-polyfill/-/eme-encryption-scheme-polyfill-2.0.4.tgz#7d818302af3f3b19d5974255dcc92dc087413845"
-  integrity sha512-MHYJX1v145Pjj2YJTrVVuJOYyXrxGVy8LWf6kV5M4jrV/GyoeuJKyTuD+GaD+VAiE8Ip+MptiH4dXk6ZVmMNow==
+eme-encryption-scheme-polyfill@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eme-encryption-scheme-polyfill/-/eme-encryption-scheme-polyfill-2.1.0.tgz#bb5a6975eff3039a102b1961150921be6a3b0c9f"
+  integrity sha512-vdkP1WyZTBI2LEU+FvbYrjawkz+5fOgSY0qicaWjs/ouVzBKvdbUHfbZ1mLHFOi3l+cdvSq4U6K55mD7J/SEbg==
 
 emittery@^0.7.1:
   version "0.7.2"
@@ -5812,14 +5812,15 @@ react-native-svg@^12.3.0:
     css-select "^4.2.1"
     css-tree "^1.0.0-alpha.39"
 
-react-native-video@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-video/-/react-native-video-5.2.0.tgz#c3f2c541775f4fda7e0d26d75a6fb59819b13d5e"
-  integrity sha512-5SK1lxyzrCkZF+WuxUxLR1Pt65E0rsWB1w1GrGxSLdC9zWYBumcmuHl+wPJ7UQvznjaH2Ze7uU1R3arejI7+WQ==
+react-native-video@^6.0.0-alpha.1:
+  version "6.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/react-native-video/-/react-native-video-6.0.0-alpha.1.tgz#4c1e663e86073553bcad2743ee238685688b0115"
+  integrity sha512-uY4rct/aMXPBCFejZqACWPI8V0Q0gqcCg1tv8UFXdSjnRW122U0HkRFw1wMnOT+YQM+SYCm5HG90/5fykSMdig==
   dependencies:
+    deprecated-react-native-prop-types "^2.2.0"
     keymirror "^0.1.1"
     prop-types "^15.7.2"
-    shaka-player "^2.5.9"
+    shaka-player "^3.3.2"
 
 react-native-view-shot@^3.3.0-next.0:
   version "3.3.0-next.0"
@@ -6301,12 +6302,12 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shaka-player@^2.5.9:
-  version "2.5.23"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-2.5.23.tgz#db92d1c6cf2314f0180a2cec11b0e2f2560336f5"
-  integrity sha512-3MC9k0OXJGw8AZ4n/ZNCZS2yDxx+3as5KgH6Tx4Q5TRboTBBCu6dYPI5vp1DxKeyU12MBN1Zcbs7AKzXv2EnCg==
+shaka-player@^3.3.2:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-3.3.8.tgz#5a59555db18b6e9cb55ede465b1c1ed929f19e7a"
+  integrity sha512-chO0cJ5iy57tqD0Ks8OcaSYaiabN+6P1Z4aDfgevczfqLeUs2u5GF0xkkreUfbPAmTmEPAsuZQ3POvyB0D++Yg==
   dependencies:
-    eme-encryption-scheme-polyfill "^2.0.1"
+    eme-encryption-scheme-polyfill "^2.0.3"
 
 shallow-clone@^3.0.0:
   version "3.0.1"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,6 +48,11 @@ declare module 'react-native-view-shot' {
          * container height.
          */
         snapshotContentContainer?: boolean;
+        /**
+         * if true and when view is a SurfaceView or have it in the view tree, view will be captured.
+         * False by default, because it can have signoficant performance impact
+         */
+        handleGLSurfaceViewOnAndroid?: boolean;
     }
 
     export interface ViewShotProperties {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ type Options = {
   format: "png" | "jpg" | "webm" | "raw",
   quality: number,
   result: "tmpfile" | "base64" | "data-uri" | "zip-base64",
-  snapshotContentContainer: boolean
+  snapshotContentContainer: boolean,
+  handleGLSurfaceViewOnAndroid: boolean
 };
 
 if (!RNViewShot) {
@@ -34,7 +35,8 @@ const defaultOptions = {
   format: "png",
   quality: 1,
   result: "tmpfile",
-  snapshotContentContainer: false
+  snapshotContentContainer: false,
+  handleGLSurfaceViewOnAndroid: false
 };
 
 // validate and coerce options
@@ -70,6 +72,9 @@ function validateOptions(
   }
   if (typeof options.snapshotContentContainer !== "boolean") {
     errors.push("option snapshotContentContainer should be a boolean");
+  }
+  if (typeof options.handleGLSurfaceViewOnAndroid !== "boolean") {
+    errors.push("option handleGLSurfaceViewOnAndroid should be a boolean");
   }
   if (acceptedFormats.indexOf(options.format) === -1) {
     options.format = defaultOptions.format;


### PR DESCRIPTION
Continues of #323.

- Use `PixelCopy.request` to capture SurfaceView content
- Update video example
  - Upgrade react-native-video to latest alpha version because v5.2 doesn't work (jcenter issue)
  - Set `useTextureView={false}` to use surface view (ref: https://github.com/react-native-video/react-native-video/blob/08c2220e1663808a7bac76babc404b51154a50af/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java#L107)
  - Keep the old video example, it used TextureView. So we can see two videos in example