### PR TITLE
Remove debug line that's causing errors in release builds

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -368,8 +368,6 @@ public class ViewShot implements UIBlock, LifecycleEventListener {
      */
     private Point captureView(@NonNull final View view, @NonNull final OutputStream os) throws IOException {
         try {
-            DebugViews.longDebug(TAG, DebugViews.logViewHierarchy(this.currentActivity));
-
             return captureViewImpl(view, os);
         } finally {
             os.close();


### PR DESCRIPTION
This line here gets triggered with every capture and apparently it just logs debugging stuff, the issue is there is no way to turn it off in release builds and it seems to be not needed.

https://github.com/gre/react-native-view-shot/issues/426

