### PR TITLE
Simplify Android background thread

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
@@ -23,6 +23,8 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import fr.greweb.reactnativeviewshot.ViewShot.Formats;
 import fr.greweb.reactnativeviewshot.ViewShot.Results;
@@ -32,6 +34,8 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
     public static final String RNVIEW_SHOT = "RNViewShot";
 
     private final ReactApplicationContext reactContext;
+
+    private final Executor executor = Executors.newCachedThreadPool();
 
     public RNViewShotModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -100,7 +104,7 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
             uiManager.addUIBlock(new ViewShot(
                     tag, extension, imageFormat, quality,
                     scaleWidth, scaleHeight, outputFile, resultStreamFormat,
-                    snapshotContentContainer, reactContext, activity, handleGLSurfaceView, promise)
+                    snapshotContentContainer, reactContext, activity, handleGLSurfaceView, promise, executor)
             );
         } catch (final Throwable ex) {
             Log.e(RNVIEW_SHOT, "Failed to snapshot view tag " + tag, ex);

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -45,6 +45,8 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.Deflater;
 
@@ -141,6 +143,7 @@ public class ViewShot implements UIBlock {
     private final ReactApplicationContext reactContext;
     private final boolean handleGLSurfaceView;
     private final Activity currentActivity;
+    private final Executor executor;
     //endregion
 
     //region Constructors
@@ -158,7 +161,8 @@ public class ViewShot implements UIBlock {
             final ReactApplicationContext reactContext,
             final Activity currentActivity,
             final boolean handleGLSurfaceView,
-            final Promise promise) {
+            final Promise promise,
+            final Executor executor) {
         this.tag = tag;
         this.extension = extension;
         this.format = format;
@@ -172,13 +176,14 @@ public class ViewShot implements UIBlock {
         this.currentActivity = currentActivity;
         this.handleGLSurfaceView = handleGLSurfaceView;
         this.promise = promise;
+        this.executor = executor;
     }
     //endregion
 
     //region Overrides
     @Override
     public void execute(final NativeViewHierarchyManager nativeViewHierarchyManager) {
-        new Thread("RNViewShot-Capture-Thread") {
+        executor.execute(new Runnable () {
             @Override
             public void run() {
                 try {
@@ -214,7 +219,7 @@ public class ViewShot implements UIBlock {
                     promise.reject(ERROR_UNABLE_TO_SNAPSHOT, "Failed to capture view snapshot");
                 }
             }
-        }.start();
+        });
     }
     //endregion
 


### PR DESCRIPTION
As the capture task is executed once, a simple thread can be used for running it instead of a handler. This way the thread stops on task completion and the ViewShot object can be GC'd rather than persisting until the host is destroyed. The hanging threads could make an app run out of memory and crash after continuous use
