### PR TITLE
Fix `ViewShotProperties.style` type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,7 +10,7 @@
 
 declare module 'react-native-view-shot' {
     import { Component, ReactInstance, RefObject, ReactNode } from 'react'
-    import { ViewStyle } from 'react-native'
+    import { StyleProp, ViewStyle } from 'react-native'
     import { LayoutChangeEvent } from 'react-native'
 
 
@@ -94,9 +94,9 @@ declare module 'react-native-view-shot' {
          */
         onLayout?(event: LayoutChangeEvent): void;
         /**
-         * style prop as ViewStyle
+         * style prop as StyleProp<ViewStyle>
          */
-        style?: ViewStyle;
+        style?: StyleProp<ViewStyle>;
     }
 
     export default class ViewShot extends Component<React.PropsWithChildren<ViewShotProperties>> {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from "react";
-import { View, Platform, findNodeHandle } from "react-native";
+import { View, Platform, findNodeHandle, StyleProp } from "react-native";
 import RNViewShot from "./RNViewShot";
 import type { ViewStyleProp } from "react-native/Libraries/StyleSheet/StyleSheet";
 import type { LayoutEvent } from "react-native/Libraries/Types/CoreEventTypes";
@@ -14,7 +14,7 @@ type Options = {
   quality: number,
   result: "tmpfile" | "base64" | "data-uri" | "zip-base64",
   snapshotContentContainer: boolean,
-  handleGLSurfaceViewOnAndroid: boolean
+  handleGLSurfaceViewOnAndroid: boolean,
 };
 
 if (!RNViewShot) {
@@ -36,16 +36,17 @@ const defaultOptions = {
   quality: 1,
   result: "tmpfile",
   snapshotContentContainer: false,
-  handleGLSurfaceViewOnAndroid: false
+  handleGLSurfaceViewOnAndroid: false,
 };
 
 // validate and coerce options
-function validateOptions(
-  input: ?$Shape<Options>
-): { options: Options, errors: Array<string> } {
+function validateOptions(input: ?$Shape<Options>): {
+  options: Options,
+  errors: Array<string>,
+} {
   const options: Options = {
     ...defaultOptions,
-    ...input
+    ...input,
   };
   const errors = [];
   if (
@@ -136,7 +137,7 @@ export function captureRef<T: React$ElementType>(
   if (__DEV__ && errors.length > 0) {
     console.warn(
       "react-native-view-shot: bad options:\n" +
-        errors.map(e => `- ${e}`).join("\n")
+        errors.map((e) => `- ${e}`).join("\n")
     );
   }
   return RNViewShot.captureRef(view, options);
@@ -158,7 +159,7 @@ export function captureScreen(optionsObject?: Options): Promise<string> {
   if (__DEV__ && errors.length > 0) {
     console.warn(
       "react-native-view-shot: bad options:\n" +
-        errors.map(e => `- ${e}`).join("\n")
+        errors.map((e) => `- ${e}`).join("\n")
     );
   }
   return RNViewShot.captureScreen(options);
@@ -171,7 +172,7 @@ type Props = {
   onLayout?: (e: *) => void,
   onCapture?: (uri: string) => void,
   onCaptureFailure?: (e: Error) => void,
-  style?: ViewStyleProp
+  style?: StyleProp<ViewStyleProp>,
 };
 
 function checkCompatibleProps(props: Props) {
@@ -204,7 +205,7 @@ export default class ViewShot extends Component<Props> {
   lastCapturedURI: ?string;
 
   resolveFirstLayout: (layout: Object) => void;
-  firstLayoutPromise: Promise<Object> = new Promise(resolve => {
+  firstLayoutPromise: Promise<Object> = new Promise((resolve) => {
     this.resolveFirstLayout = resolve;
   });
 


### PR DESCRIPTION
found typescript error when set `style` as array e.g. `style={[style1, style2]}`

change `ViewShotProperties.style` type to use same type of `ViewProps.style`