### PR TITLE
(Web) Add backgroundColor to captureRef

### DIFF
--- a/src/RNViewShot.web.js
+++ b/src/RNViewShot.web.js
@@ -9,7 +9,9 @@ async function captureRef(view, options) {
 
   // TODO: implement snapshotContentContainer option
 
-  const h2cOptions = {};
+  const h2cOptions = {
+    backgroundColor: options.backgroundColor || null
+  };
   let renderedCanvas = await html2canvas(view, h2cOptions);
 
   if (options.width && options.height) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -60,6 +60,10 @@ declare module 'react-native-view-shot' {
          * which may help for some use cases.
          */
         useRenderInContext?: boolean;
+        /**
+         * (Web only) the background color of captured image. Set null for transparent. Default is null.
+         */
+        backgroundColor?: string;
     }
 
     export interface ViewShotProperties {


### PR DESCRIPTION
Html2canvas have backgroundColor option which is sets background color of captured image. Default value is "#FFFFFF" so if you capture image on web, there will be a white border on bottom. We need to add option to set html2canvas background. This pr does this.

I also set default value to **null** which is corresponds "transparent" on html2canvas side. This matches the native behavior better(iOS, Android).

**Reproduce**:
```jsx
<View ref={viewRef} style={{ backgroundColor: "red", width: 50 }}>Test</View>
```
**Before**:
![image](https://github.com/gre/react-native-view-shot/assets/7578884/52591983-2fd9-4bb6-ab2e-921362978de4)
**After** `{ backgroundColor: "red" }`:
![image](https://github.com/gre/react-native-view-shot/assets/7578884/08a6da5b-e72d-4b13-84b9-3edfa804c21d)
