### PR TITLE
chore(android): add support for AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,6 +11,13 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
 
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    // Check the AGP version, add namespace if the AGP version is above 7.
+    // Once we have fully moved on, we can remove it from the AndroidManifest.xml of the package
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace "fr.greweb.reactnativeviewshot"
+    }
+
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)


### PR DESCRIPTION
AGP 8 requires the use of namespace in the gradle file, and deprecates using it in the Manifest. Per instructions from [the core team](https://github.com/react-native-community/discussions-and-proposals/issues/671), we need to update it, otherwise installations will fail on 73. AGP 7 also supports namespace, hence why we are adding it from 7 and above

@gre let me know if you need me to change anything more