### PR TITLE
Fix: iOS base64 and data-uri formats add unnecessary line breaks to base64 string

### DIFF
--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -152,11 +152,11 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
       NSString *res = nil;
       if ([result isEqualToString:@"base64"]) {
         // Return as a base64 raw string
-        res = [data base64EncodedStringWithOptions: NSDataBase64Encoding64CharacterLineLength];
+        res = [data base64EncodedStringWithOptions: 0];
       }
       else if ([result isEqualToString:@"data-uri"]) {
         // Return as a base64 data uri string
-        NSString *base64 = [data base64EncodedStringWithOptions: NSDataBase64Encoding64CharacterLineLength];
+        NSString *base64 = [data base64EncodedStringWithOptions: 0];
         NSString *imageFormat = ([format isEqualToString:@"jpg"]) ? @"jpeg" : format;
         res = [NSString stringWithFormat:@"data:image/%@;base64,%@", imageFormat, base64];
       }


### PR DESCRIPTION
# What

After upgrading the React Native version to 0.72 I started to notice problems with displaying base64 view shots in `<Image />` components. Turns out it was because there were line breaks in the base64 string produced by the view shot library.

The line breaks were there all the time, but I think they might unnecessary.
Android implementation produces base64 string without line breaks.

# Changes

I changed the options passed to `base64EncodeStringWithOptions` call in Objective-C. The options that can be passed are an ObjC option set. The options have values which is value of 1 but bit shifted left by different offsets. The initial value is 1 then 2, 4 etc. These options can be combined using logical OR `|` but we can also pass none by passing value of 0.

I found some information here https://apple-dev.groups.io/g/cocoa/topic/nsdata_base64encoding_vs/17101984

Let me know what you think of this change. I tested it in my project and it now lives there as a `patch-package` patch.


