### PR TITLE
feat: replaced depricated apis with new ones for ui image

### DIFF
--- a/ios/RNViewShot.m
+++ b/ios/RNViewShot.m
@@ -106,7 +106,7 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
       scrollView.frame = CGRectMake(0, 0, scrollView.contentSize.width, scrollView.contentSize.height);
     }
 
-    UIGraphicsBeginImageContextWithOptions(size, NO, 0);
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size];
     
     if (renderInContext) {
       // this comes with some trade-offs such as inability to capture gradients or scrollview's content in full but it works for large views
@@ -117,8 +117,8 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
       // this doesn't work for large views and reports incorrect success even though the image is blank
       success = [rendered drawViewHierarchyInRect:(CGRect){CGPointZero, size} afterScreenUpdates:YES];
     }
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
+   
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {}];
 
     if (snapshotContentContainer) {
       // Restore scroll & frame


### PR DESCRIPTION
Building with Xcode 15 for iOS 17 lead to the run-time crash when using a deprecated UIGraphicsBeginImageContextWithOptions code on the UIImage instances with .zero size.

Following UI Image apis are depricated from ios 17 when build with Xcode 15:

https://developer.apple.com/documentation/uikit/1623912-uigraphicsbeginimagecontextwitho
https://developer.apple.com/documentation/uikit/1623924-uigraphicsgetimagefromcurrentima

Instead need to use UIGraphicsImageRenderer and UIGraphicsImageRendererContext. Have replaced them in this pr.