### PR TITLE
[0.74] Add support for Fabric & Bridgeless Mode

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,14 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def isNewArchitectureEnabled() {
+    return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+}
+
 apply plugin: 'com.android.library'
+if (isNewArchitectureEnabled()) {
+    apply plugin: 'com.facebook.react'
+}
 
 
 android {
@@ -23,6 +30,11 @@ android {
         targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
         versionCode 1
         versionName "1.0"
+        buildConfigField("boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString())
+    }
+
+    buildFeatures {
+        buildConfig true
     }
 }
 

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotPackage.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotPackage.java
@@ -1,29 +1,44 @@
 
 package fr.greweb.reactnativeviewshot;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
-import com.facebook.react.ReactPackage;
+import com.facebook.react.TurboReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.uimanager.ViewManager;
-import com.facebook.react.bridge.JavaScriptModule;
-public class RNViewShotPackage implements ReactPackage {
-    @Override
-    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-      return Arrays.<NativeModule>asList(new RNViewShotModule(reactContext));
-    }
+import com.facebook.react.module.model.ReactModuleInfo;
+import com.facebook.react.module.model.ReactModuleInfoProvider;
 
-    // Deprecated RN 0.47
-    // @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
+import java.util.HashMap;
+import java.util.Map;
 
-    @Override
-    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-      return Collections.emptyList();
+public class RNViewShotPackage extends TurboReactPackage {
+  @Nullable
+  @Override
+  public NativeModule getModule(@NonNull String name, @NonNull ReactApplicationContext reactApplicationContext) {
+    if (name.equals(RNViewShotModule.RNVIEW_SHOT)) {
+      return new RNViewShotModule(reactApplicationContext);
+    } else {
+      return null;
     }
+  }
+
+  @Override
+  public ReactModuleInfoProvider getReactModuleInfoProvider() {
+    return () -> {
+      final Map<String, ReactModuleInfo> moduleInfos = new HashMap<>();
+      moduleInfos.put(
+              RNViewShotModule.RNVIEW_SHOT,
+              new ReactModuleInfo(
+                      RNViewShotModule.RNVIEW_SHOT,
+                      RNViewShotModule.RNVIEW_SHOT,
+                      false, // canOverrideExistingModule
+                      false, // needsEagerInit
+                      false, // isCxxModule
+                      true // isTurboModule
+              ));
+      return moduleInfos;
+    };
+  }
 }

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -26,6 +26,7 @@ import android.widget.ScrollView;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.fabric.interop.UIBlockViewResolver;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
 import com.facebook.react.uimanager.UIBlock;
 
@@ -57,7 +58,7 @@ import static android.view.View.VISIBLE;
 /**
  * Snapshot utility class allow to screenshot a view.
  */
-public class ViewShot implements UIBlock {
+public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBlock {
     //region Constants
     /**
      * Tag fort Class logs.
@@ -183,6 +184,17 @@ public class ViewShot implements UIBlock {
     //region Overrides
     @Override
     public void execute(final NativeViewHierarchyManager nativeViewHierarchyManager) {
+        executeImpl(nativeViewHierarchyManager, null);
+    }
+
+    @Override
+    public void execute(@NonNull UIBlockViewResolver uiBlockViewResolver) {
+        executeImpl(null, uiBlockViewResolver);
+    }
+    //endregion
+
+    //region Implementation
+    private void executeImpl(final NativeViewHierarchyManager nativeViewHierarchyManager, final UIBlockViewResolver uiBlockViewResolver) {
         executor.execute(new Runnable () {
             @Override
             public void run() {
@@ -191,6 +203,8 @@ public class ViewShot implements UIBlock {
 
                     if (tag == -1) {
                         view = currentActivity.getWindow().getDecorView().findViewById(android.R.id.content);
+                    } else if (uiBlockViewResolver != null) {
+                        view = uiBlockViewResolver.resolveView(tag);
                     } else {
                         view = nativeViewHierarchyManager.resolveView(tag);
                     }
@@ -221,9 +235,7 @@ public class ViewShot implements UIBlock {
             }
         });
     }
-    //endregion
 
-    //region Implementation
     private void saveToTempFileOnDevice(@NonNull final View view) throws IOException {
         final FileOutputStream fos = new FileOutputStream(output);
         captureView(view, fos);

--- a/package.json
+++ b/package.json
@@ -30,5 +30,13 @@
     "flow-bin": "^0.170.0",
     "html-webpack-plugin": "^5.5.1",
     "react-native-windows": "^0.63.16"
+  },
+  "codegenConfig": {
+    "name": "RNViewShot",
+    "type": "all",
+    "jsSrcsDir": "./src/specs",
+    "android": {
+      "javaPackageName": "fr.greweb.reactnativeviewshot"
+    }
   }
 }

--- a/src/RNViewShot.js
+++ b/src/RNViewShot.js
@@ -1,3 +1,3 @@
 //@flow
-import { NativeModules } from "react-native";
-export default NativeModules.RNViewShot
+import { RNViewShot } from './specs/NativeRNViewShot'
+export default RNViewShot

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from "react";
 import { View, Platform, findNodeHandle, StyleProp } from "react-native";
-import RNViewShot from "./RNViewShot";
+import RNViewShot from "./specs/NativeRNViewShot";
 import type { ViewStyleProp } from "react-native/Libraries/StyleSheet/StyleSheet";
 import type { LayoutEvent } from "react-native/Libraries/Types/CoreEventTypes";
 
@@ -19,7 +19,7 @@ type Options = {
 
 if (!RNViewShot) {
   console.warn(
-    "react-native-view-shot: NativeModules.RNViewShot is undefined. Make sure the library is linked on the native side."
+    "react-native-view-shot: RNViewShot is undefined. Make sure the library is linked on the native side."
   );
 }
 

--- a/src/specs/NativeRNViewShot.ts
+++ b/src/specs/NativeRNViewShot.ts
@@ -1,0 +1,10 @@
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+
+export interface Spec extends TurboModule {
+  releaseCapture: () => string;
+  captureRef: (tag: number, options: Object) => Promise<string>
+  captureScreen: (options: Object) => Promise<string>;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('RNViewShot');


### PR DESCRIPTION
Fixes #469
Fixes #452

This PR adds support for Bridgeless & Fabric as of React Native 0.74.
To test it you need to either wait for RC5 (out next week) or build from source as there is a change needed inside React Native core to make this work:
- https://github.com/facebook/react-native/pull/43594?fbclid=IwAR2YtMWEDiV7L1PAXpYEMKM3kxLXq-T8dN38WLB8tcX-5ptmUr1UdXgp0T0

I've tested it on RN-Tester from `main`, here the results.

@gre I'd like to get your support to do some further testing.

### Testing

|   | Before (Old Arch) | Before (New Arch) | After (Old Arch) | After (NewArch/Bridgeless) |
| - | ----------------- | ----------------- | ---------------- | -------------------------- | 
| App behavior | ![Screenshot_1711028751](https://github.com/gre/react-native-view-shot/assets/3001957/330d38ef-58fb-4080-b8cb-3f1efd1c1cd7) | ![Screenshot_1711028891](https://github.com/gre/react-native-view-shot/assets/3001957/a3d40f6f-2909-4749-b13b-89f2c6d3f2c2) | ![Screenshot_1711028488](https://github.com/gre/react-native-view-shot/assets/3001957/9c012ecd-030d-4c1a-9cf1-5fe10598985b) | ![Screenshot_1711028577](https://github.com/gre/react-native-view-shot/assets/3001957/5dac7db8-294c-404c-998d-61405c9b7f60) |
| Screenshots | ![before-oldarch](https://github.com/gre/react-native-view-shot/assets/3001957/fa6bb77a-0568-473b-8ae9-aaa5b061517c) | N/A (does not work) | ![after-oldarch](https://github.com/gre/react-native-view-shot/assets/3001957/dbd1dd46-426c-440a-b86a-6740659e0620) | ![after-bridgeless](https://github.com/gre/react-native-view-shot/assets/3001957/c95436b5-6359-4a52-a3c7-b764e3655dcc) |






