### PR TITLE
fix react-native 0.74 Use invalidate method instead onCatalystInstanceDestroy

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
@@ -58,8 +58,8 @@ public class RNViewShotModule extends ReactContextBaseJavaModule implements Turb
     }
 
     @Override
-    public void onCatalystInstanceDestroy() {
-        super.onCatalystInstanceDestroy();
+    public void invalidate() {
+        super.invalidate();
         new CleanTask(getReactApplicationContext()).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 


### PR DESCRIPTION
fix react-native 0.74 Use invalidate method instead onCatalystInstanceDestroy 