### PR TITLE
docs: Update Expo installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ yarn add react-native-view-shot
 
 # In Expo
 
-expo install react-native-view-shot
+npx expo install react-native-view-shot
 ```
 
 Make sure `react-native-view-shot` is correctly linked in Xcode (might require a manual installation, refer to [React Native doc](https://reactnative.dev/docs/linking-libraries-ios.html)).


### PR DESCRIPTION
Hi there 👋 ,

I noticed that the installation instructions for the Expo were outdated, and this PR updated them using the preferred `npx expo install ...`.

With the current set of supported SDKs, the `expo install` command referees to the global CLI which is now deprecated and removed. The new Expo CLI which is packaged inside the any Expo project created uses `npx expo install ...` command to install the library.

Thanks!