### PR TITLE
fix: move view resolver out of the executor thread

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -195,26 +195,26 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
 
     //region Implementation
     private void executeImpl(final NativeViewHierarchyManager nativeViewHierarchyManager, final UIBlockViewResolver uiBlockViewResolver) {
+        final View view;
+
+        if (tag == -1) {
+            view = currentActivity.getWindow().getDecorView().findViewById(android.R.id.content);
+        } else if (uiBlockViewResolver != null) {
+            view = uiBlockViewResolver.resolveView(tag);
+        } else {
+            view = nativeViewHierarchyManager.resolveView(tag);
+        }
+
+        if (view == null) {
+            Log.e(TAG, "No view found with reactTag: " + tag, new AssertionError());
+            promise.reject(ERROR_UNABLE_TO_SNAPSHOT, "No view found with reactTag: " + tag);
+            return;
+        }
+
         executor.execute(new Runnable () {
             @Override
             public void run() {
                 try {
-                    final View view;
-
-                    if (tag == -1) {
-                        view = currentActivity.getWindow().getDecorView().findViewById(android.R.id.content);
-                    } else if (uiBlockViewResolver != null) {
-                        view = uiBlockViewResolver.resolveView(tag);
-                    } else {
-                        view = nativeViewHierarchyManager.resolveView(tag);
-                    }
-
-                    if (view == null) {
-                        Log.e(TAG, "No view found with reactTag: " + tag, new AssertionError());
-                        promise.reject(ERROR_UNABLE_TO_SNAPSHOT, "No view found with reactTag: " + tag);
-                        return;
-                    }
-
                     final ReusableByteArrayOutputStream stream = new ReusableByteArrayOutputStream(outputBuffer);
                     stream.setSize(proposeSize(view));
                     outputBuffer = stream.innerBuffer();


### PR DESCRIPTION
This fix a warning on capture because the view resolver is called in the executor thread but it should be in the UI thread, since the ViewShot class implements UIBlock and is dispatched to the UI manager queue we only need to move the "view resolver" out of the executor thread. 

Issue: https://github.com/gre/react-native-view-shot/issues/493

In my case even though the error is displayed the image is generated successfully because the "error" is just  a assert that warning in debug mode: https://github.com/facebook/react-native/blob/9afad527b831ec0c5d50e88daacbaacbc476d478/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java#L925

Patch for testing:
```diff
diff --git a/node_modules/react-native-view-shot/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java b/node_modules/react-native-view-shot/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
index ce81dda..7b7332b 100644
--- a/node_modules/react-native-view-shot/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/node_modules/react-native-view-shot/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -195,26 +195,26 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
 
     //region Implementation
     private void executeImpl(final NativeViewHierarchyManager nativeViewHierarchyManager, final UIBlockViewResolver uiBlockViewResolver) {
+        final View view;
+
+        if (tag == -1) {
+            view = currentActivity.getWindow().getDecorView().findViewById(android.R.id.content);
+        } else if (uiBlockViewResolver != null) {
+            view = uiBlockViewResolver.resolveView(tag);
+        } else {
+            view = nativeViewHierarchyManager.resolveView(tag);
+        }
+
+        if (view == null) {
+            Log.e(TAG, "No view found with reactTag: " + tag, new AssertionError());
+            promise.reject(ERROR_UNABLE_TO_SNAPSHOT, "No view found with reactTag: " + tag);
+            return;
+        }
+
         executor.execute(new Runnable () {
             @Override
             public void run() {
                 try {
-                    final View view;
-
-                    if (tag == -1) {
-                        view = currentActivity.getWindow().getDecorView().findViewById(android.R.id.content);
-                    } else if (uiBlockViewResolver != null) {
-                        view = uiBlockViewResolver.resolveView(tag);
-                    } else {
-                        view = nativeViewHierarchyManager.resolveView(tag);
-                    }
-
-                    if (view == null) {
-                        Log.e(TAG, "No view found with reactTag: " + tag, new AssertionError());
-                        promise.reject(ERROR_UNABLE_TO_SNAPSHOT, "No view found with reactTag: " + tag);
-                        return;
-                    }
-
                     final ReusableByteArrayOutputStream stream = new ReusableByteArrayOutputStream(outputBuffer);
                     stream.setSize(proposeSize(view));
                     outputBuffer = stream.innerBuffer();

```