### PR TITLE
fix: tmpfile not supported on web error when using base64 result

### DIFF
--- a/src/RNViewShot.web.js
+++ b/src/RNViewShot.web.js
@@ -3,8 +3,10 @@ import html2canvas from "html2canvas";
 
 async function captureRef(view, options) {
   if (options.result === "tmpfile") {
-    console.warn("Tmpfile is not implemented for web. Try base64 or file.\n"+
-                 "For compatibility, it currently returns the same result as data-uri");
+    console.warn(
+      "Tmpfile is not implemented for web. Try base64 or file.\n" +
+        "For compatibility, it currently returns the same result as data-uri"
+    );
   }
 
   // TODO: implement snapshotContentContainer option
@@ -14,17 +16,27 @@ async function captureRef(view, options) {
 
   if (options.width && options.height) {
     // Resize result
-    const resizedCanvas = document.createElement('canvas');
-    const resizedContext = resizedCanvas.getContext('2d');
+    const resizedCanvas = document.createElement("canvas");
+    const resizedContext = resizedCanvas.getContext("2d");
     resizedCanvas.height = options.height;
     resizedCanvas.width = options.width;
-    resizedContext.drawImage(renderedCanvas, 0, 0, resizedCanvas.width, resizedCanvas.height);
+    resizedContext.drawImage(
+      renderedCanvas,
+      0,
+      0,
+      resizedCanvas.width,
+      resizedCanvas.height
+    );
     renderedCanvas = resizedCanvas;
   }
 
-  const dataUrl = renderedCanvas.toDataURL("image/" + options.format, options.quality);
-  if (options.result === "data-uri" || options.result === "tmpfile") return dataUrl;
-  return dataUrl.replace(/data:image\/(\w+);base64,/, '');
+  const dataUrl = renderedCanvas.toDataURL(
+    "image/" + options.format,
+    options.quality
+  );
+  if (options.result === "data-uri" || options.result === "tmpfile")
+    return dataUrl;
+  return dataUrl.replace(/data:image\/(\w+);base64,/, "");
 }
 
 function captureScreen(options) {
@@ -32,11 +44,13 @@ function captureScreen(options) {
 }
 
 function releaseCapture(uri) {
-  throw new Error("Tmpfile is not implemented for web. Try base64 or file");
+  if (options.result === "tmpfile") {
+    throw new Error("Tmpfile is not implemented for web. Try base64 or file");
+  }
 }
 
 export default {
   captureRef,
   captureScreen,
-  releaseCapture
-}
+  releaseCapture,
+};

--- a/src/RNViewShot.web.js
+++ b/src/RNViewShot.web.js
@@ -3,10 +3,8 @@ import html2canvas from "html2canvas";
 
 async function captureRef(view, options) {
   if (options.result === "tmpfile") {
-    console.warn(
-      "Tmpfile is not implemented for web. Try base64 or file.\n" +
-        "For compatibility, it currently returns the same result as data-uri"
-    );
+    console.warn("Tmpfile is not implemented for web. Try base64 or file.\n"+
+                 "For compatibility, it currently returns the same result as data-uri");
   }
 
   // TODO: implement snapshotContentContainer option
@@ -16,27 +14,17 @@ async function captureRef(view, options) {
 
   if (options.width && options.height) {
     // Resize result
-    const resizedCanvas = document.createElement("canvas");
-    const resizedContext = resizedCanvas.getContext("2d");
+    const resizedCanvas = document.createElement('canvas');
+    const resizedContext = resizedCanvas.getContext('2d');
     resizedCanvas.height = options.height;
     resizedCanvas.width = options.width;
-    resizedContext.drawImage(
-      renderedCanvas,
-      0,
-      0,
-      resizedCanvas.width,
-      resizedCanvas.height
-    );
+    resizedContext.drawImage(renderedCanvas, 0, 0, resizedCanvas.width, resizedCanvas.height);
     renderedCanvas = resizedCanvas;
   }
 
-  const dataUrl = renderedCanvas.toDataURL(
-    "image/" + options.format,
-    options.quality
-  );
-  if (options.result === "data-uri" || options.result === "tmpfile")
-    return dataUrl;
-  return dataUrl.replace(/data:image\/(\w+);base64,/, "");
+  const dataUrl = renderedCanvas.toDataURL("image/" + options.format, options.quality);
+  if (options.result === "data-uri" || options.result === "tmpfile") return dataUrl;
+  return dataUrl.replace(/data:image\/(\w+);base64,/, '');
 }
 
 function captureScreen(options) {
@@ -52,5 +40,5 @@ function releaseCapture(uri) {
 export default {
   captureRef,
   captureScreen,
-  releaseCapture,
-};
+  releaseCapture
+}


### PR DESCRIPTION
I was pleasantly surprised this is working perfectly for my use case on the web, except for one small error thrown, even when the result option is set to base64.  The release capture function (on web) was set to just throw an error, always.

Original:
```js
function releaseCapture(uri) {
  throw new Error("Tmpfile is not implemented for web. Try base64 or file");
}
```
I added a quick little conditional to only throw the error if options.results type is tmpfile.
```js
function releaseCapture(uri) {
  if (options.result === "tmpfile") {
    throw new Error("Tmpfile is not implemented for web. Try base64 or file");
  }
}
```