### PR TITLE
Fix captureRef crash on web (findNodeHandle not supported)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,20 @@ A full React Native app demonstrating all features. Each feature has its own scr
 
 E2E snapshot references live in `example/e2e/snapshots/reference/{ios,android}/` — platform-separated because rendering differs. Test outputs go to `example/e2e/snapshots/output/` (gitignored).
 
+### Web Example App (`example-web/`)
+
+A standalone web example using `react-native-web` + `html2canvas` + webpack. Webpack alias resolves `react-native-view-shot` to `../src` (the local lib source). Also has Playwright E2E tests.
+
+```bash
+cd example-web
+npm start              # webpack dev server on port 3000
+npm run build          # Production build → dist/
+```
+
+### Windows Example App (`example-windows/`)
+
+A React Native Windows example app.
+
 ## Key Behaviors
 
 - **Architecture detection**: `src/specs/NativeRNViewShot.ts` checks `global.__turboModuleProxy` at runtime to decide between `TurboModuleRegistry` (new arch) and `NativeModules` (old arch).

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -192,7 +192,7 @@ export function captureRef<T = any>(
       return Promise.reject(new Error("ref.current is null"));
     }
   }
-  if (typeof viewHandle !== "number") {
+  if (Platform.OS !== "web" && typeof viewHandle !== "number") {
     const node = findNodeHandle(viewHandle);
     if (!node) {
       return Promise.reject(


### PR DESCRIPTION
## Summary

- Skip `findNodeHandle` on web platform, where it is not available
- Pass the DOM element ref directly to the `html2canvas`-based web implementation instead

Fixes #586

## Test plan

- [x] Library builds and type-checks
- [x] Tested manually with `example-web` app — capture works without `findNodeHandle` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)