### PR TITLE
Add iOS Privacy Manifest (PrivacyInfo.xcprivacy)

### DIFF
--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/react-native-view-shot.podspec
+++ b/react-native-view-shot.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/gre/react-native-view-shot.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,mm}"
+  s.resource_bundles = { 'RNViewShotPrivacyInfo' => ['ios/PrivacyInfo.xcprivacy'] }
 
   install_modules_dependencies(s)
 end


### PR DESCRIPTION
## Summary
- Adds `PrivacyInfo.xcprivacy` to `ios/` — required by Apple since May 2024 for all third-party SDKs
- References it via `resource_bundles` in the podspec (avoids Xcode build conflicts with other pods)
- The manifest is minimal: the library does not use any required reason APIs, does not collect data, and does not track users

Closes #530

## Test plan
- [x] Verify `pod install` picks up the new resource bundle
- [ ] Verify Xcode build succeeds with the privacy manifest included
- [ ] Verify App Store submission no longer warns about missing privacy manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)