### PR TITLE
Fix JPG format and base64 preview on web

### DIFF
--- a/example-web/src/screens/BasicTestScreen.tsx
+++ b/example-web/src/screens/BasicTestScreen.tsx
@@ -32,7 +32,12 @@ const BasicTestScreen: React.FC<Props> = ({goBack}) => {
           quality: 0.9,
           result,
         });
-        setImageUri(uri);
+        if (result === "base64") {
+          const mime = format === "jpg" ? "jpeg" : format;
+          setImageUri(`data:image/${mime};base64,${uri}`);
+        } else {
+          setImageUri(uri);
+        }
         console.log(
           "Screenshot captured successfully:",
           uri.substring(0, 100) + "...",

--- a/src/RNViewShot.web.ts
+++ b/src/RNViewShot.web.ts
@@ -38,10 +38,9 @@ async function captureRef(
     renderedCanvas = resizedCanvas;
   }
 
-  const dataUrl = renderedCanvas.toDataURL(
-    "image/" + options.format,
-    options.quality,
-  );
+  const mimeType =
+    "image/" + (options.format === "jpg" ? "jpeg" : options.format);
+  const dataUrl = renderedCanvas.toDataURL(mimeType, options.quality);
   if (options.result === "data-uri" || options.result === "tmpfile")
     return dataUrl;
   return dataUrl.replace(/data:image\/(\w+);base64,/, "");


### PR DESCRIPTION
## Summary
- Fix JPG captures silently producing PNG on web: `toDataURL("image/jpg")` is not a valid MIME type, browsers require `"image/jpeg"`. Now maps `"jpg"` → `"jpeg"` before calling `toDataURL`.
- Fix base64 result appearing blank in example: raw base64 was used directly as `<Image source={{uri}}>`, which doesn't work without the `data:image/...;base64,` prefix.

Ref #586

## Test plan
- [x] `npm run type-check` / `npm run lint:ci` pass
- [ ] Open example-web, test all 4 capture buttons on BasicTestScreen:
  - PNG (Data URI) — works as before
  - JPG (Data URI) — now produces actual JPEG
  - PNG (Base64) — now displays correctly (was blank)
  - JPG (Base64) — now displays correctly (was blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)