### PR TITLE
Add CI workflow to build downloadable example APK

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,64 @@
+name: Build Example APK
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-example-apk:
+    name: Build Example APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+
+      - name: Build library
+        run: npm run build
+
+      - name: Install example dependencies
+        working-directory: example
+        run: npm ci --legacy-peer-deps
+
+      - name: Build release APK
+        working-directory: example/android
+        run: ./gradlew assembleRelease --no-daemon --stacktrace
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-apk
+          path: example/android/app/build/outputs/apk/release/app-release.apk
+          retention-days: 30


### PR DESCRIPTION
## Summary
- Add a new `build-apk.yml` GitHub Actions workflow that builds a **release APK** of the example app
- The APK bundles JS, so it's standalone (no Metro needed) and easy to install on any Android device for testing
- Triggered on push/PR to master and manually via `workflow_dispatch`
- APK uploaded as artifact with 30-day retention

## Test plan
- [ ] CI workflow runs successfully
- [ ] APK artifact is downloadable from the workflow run
- [ ] APK installs and runs on an Android device

🤖 Generated with [Claude Code](https://claude.com/claude-code)