### PR TITLE
fix: correct react-native.config.js for library linking on Android

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,12 +1,19 @@
-module.exports = {
-  project: {
-    ios: {},
-    android: {},
-    windows: {
-      sourceDir: "windows",
-      solutionFile: "RNViewShot.sln",
-      project: {
-        projectFile: "RNViewShot\\RNViewShot.csproj",
+export default {
+  dependency: {
+    platforms: {
+      ios: {},
+      android: {
+        sourceDir: "./android",
+        packageImportPath:
+          "import fr.greweb.reactnativeviewshot.RNViewShotPackage;",
+        packageInstance: "new RNViewShotPackage()",
+      },
+      windows: {
+        sourceDir: "windows",
+        solutionFile: "RNViewShot.sln",
+        project: {
+          projectFile: "RNViewShot\\RNViewShot.csproj",
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

- Use `dependency.platforms` instead of `project` — `project` is for app configs, `dependency` is the correct key for libraries
- Switch to ESM `export default` to match `"type": "module"` in `package.json`
- Add explicit Android `sourceDir`, `packageImportPath`, and `packageInstance` so the CLI can properly auto-link the native module

This fixes `NativeModules.RNViewShot` being `undefined` on Android with React Native 0.84+.

Closes #619

## Test plan

- [ ] Build and run example app on Android (new arch + old arch)
- [ ] Verify `captureRef` works on Android after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)