### PR TITLE
fix(android): restore autolinking and runtime on RN 0.84 + new arch

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build release APK
         working-directory: example/android
-        run: ./gradlew assembleRelease --no-daemon --stacktrace
+        run: ./gradlew assembleRelease --no-daemon --stacktrace -PnewArchEnabled=true
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,6 +1,19 @@
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 const path = require('path');
 
+const projectRoot = __dirname;
+const monorepoRoot = path.resolve(projectRoot, '..');
+
+// Block the lib's own node_modules/{react,react-native} so Metro doesn't bundle
+// duplicate copies (the lib's devDeps + the example's deps), which breaks hooks
+// in React 19 because only one copy gets its dispatcher set by the renderer.
+const blockedParentModule = name =>
+  new RegExp(
+    path
+      .resolve(monorepoRoot, 'node_modules', name, '.*')
+      .replace(/[/\\]/g, '[/\\\\]'),
+  );
+
 /**
  * Metro configuration
  * https://reactnative.dev/docs/metro
@@ -8,21 +21,18 @@ const path = require('path');
  * @type {import('@react-native/metro-config').MetroConfig}
  */
 const config = {
-  projectRoot: __dirname,
-  watchFolders: [
-    // Inclure le dossier parent pour pouvoir résoudre react-native-view-shot
-    path.resolve(__dirname, '..'),
-  ],
+  projectRoot,
+  watchFolders: [monorepoRoot],
   resolver: {
-    nodeModulesPaths: [
-      path.resolve(__dirname, './node_modules'),
-      path.resolve(__dirname, '../node_modules'),
-    ],
-    // Force la résolution vers le dossier parent pour react-native-view-shot
+    nodeModulesPaths: [path.resolve(projectRoot, 'node_modules')],
     alias: {
-      'react-native-view-shot': path.resolve(__dirname, '..'),
+      'react-native-view-shot': monorepoRoot,
     },
+    blockList: [
+      blockedParentModule('react-native'),
+      blockedParentModule('react'),
+    ],
   },
 };
 
-module.exports = mergeConfig(getDefaultConfig(__dirname), config);
+module.exports = mergeConfig(getDefaultConfig(projectRoot), config);

--- a/package.json
+++ b/package.json
@@ -5,15 +5,7 @@
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "react-native": {
-    "windows": {
-      "sourceDir": "windows",
-      "solutionFile": "RNViewShot.sln",
-      "project": {
-        "projectFile": "RNViewShot\\RNViewShot.csproj"
-      }
-    }
-  },
+  "react-native": "src/index.tsx",
   "keywords": [
     "react-native",
     "screenshot",

--- a/react-native.config.cjs
+++ b/react-native.config.cjs
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   dependency: {
     platforms: {
       ios: {},

--- a/src/__tests__/ViewShot.test.tsx
+++ b/src/__tests__/ViewShot.test.tsx
@@ -265,6 +265,53 @@ describe("ViewShot component", () => {
     await act(async () => tree!.unmount());
   });
 
+  it("forwards ref to the inner View node with capture() attached", async () => {
+    const ref = React.createRef<any>();
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<ViewShot ref={ref} />);
+    });
+    expect(ref.current).toBeTruthy();
+    // Inner View mock exposes _nativeTag via useImperativeHandle, so
+    // findNodeHandle(ref.current) keeps working as in v4.
+    expect(ref.current._nativeTag).toBe(1);
+    expect(typeof ref.current.capture).toBe("function");
+    await act(async () => tree!.unmount());
+  });
+
+  it("supports a function ref forwarded to the inner View", async () => {
+    const refFn = jest.fn();
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<ViewShot ref={refFn} />);
+    });
+    const calls = refFn.mock.calls.filter(([n]) => n);
+    expect(calls.length).toBeGreaterThan(0);
+    const node = calls[calls.length - 1][0];
+    expect(node._nativeTag).toBe(1);
+    expect(typeof node.capture).toBe("function");
+    await act(async () => tree!.unmount());
+  });
+
+  it("ref.current.capture() resolves via native captureRef after first layout", async () => {
+    const ref = React.createRef<any>();
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<ViewShot ref={ref} />);
+    });
+
+    const json = tree!.toJSON() as any;
+    await act(async () => {
+      json.props.onLayout({
+        nativeEvent: {layout: {x: 0, y: 0, width: 100, height: 100}},
+      });
+    });
+
+    await expect(ref.current.capture()).resolves.toBe("/tmp/captured.png");
+    expect(mockCaptureRef).toHaveBeenCalled();
+    await act(async () => tree!.unmount());
+  });
+
   it("forwards onLayout to props.onLayout", async () => {
     const onLayout = jest.fn();
     let tree: renderer.ReactTestRenderer;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,12 @@
-import React, {Component, ReactNode, RefObject} from "react";
+import React, {
+  ReactNode,
+  RefObject,
+  useRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  forwardRef,
+} from "react";
 import {
   View,
   Platform,
@@ -262,115 +270,159 @@ function checkCompatibleProps(props: ViewShotProperties): void {
   }
 }
 
-export default class ViewShot extends Component<ViewShotProperties> {
-  static captureRef = captureRef;
-  static releaseCapture = releaseCapture;
+/**
+ * Ref handle exposed by ViewShot component.
+ *
+ * The ref points to the inner host View so that `findNodeHandle(ref.current)`
+ * (used by `captureRef(ref, options)`) keeps working as in v4. A `capture()`
+ * method is attached to that node for the imperative `ref.current.capture()`
+ * usage.
+ */
+export type ViewShotRef = View & {
+  capture: () => Promise<string>;
+};
 
-  root: any = null;
-  _raf: number | null = null;
-  lastCapturedURI: string | null = null;
+const ViewShotComponent = forwardRef<ViewShotRef, ViewShotProperties>(
+  function ViewShot(props, ref) {
+    const {
+      children,
+      options,
+      captureMode,
+      onCapture,
+      onCaptureFailure,
+      onLayout,
+      style,
+    } = props;
 
-  resolveFirstLayout: ((layout: any) => void) | null = null;
-  firstLayoutPromise: Promise<any> = new Promise(resolve => {
-    this.resolveFirstLayout = resolve;
-  });
+    const rootRef = useRef<View>(null);
+    const rafRef = useRef<number | null>(null);
+    const lastCapturedURIRef = useRef<string | null>(null);
+    const resolveFirstLayoutRef = useRef<((layout: any) => void) | null>(null);
 
-  capture = (): Promise<string> =>
-    this.firstLayoutPromise
-      .then(() => {
-        const {root} = this;
-        if (!root) return neverEndingPromise as Promise<never>; // component is unmounted, you never want to hear back from the promise
-        return captureRef(root, this.props.options);
-      })
-      .then(
-        uri => {
-          this.onCapture(uri);
-          return uri;
-        },
-        e => {
-          this.onCaptureFailure(e);
-          throw e;
-        },
-      ) as Promise<string>;
+    const firstLayoutPromise = useMemo(
+      () =>
+        new Promise<any>(resolve => {
+          resolveFirstLayoutRef.current = resolve;
+        }),
+      [],
+    );
 
-  onCapture = (uri: string): void => {
-    if (!this.root) return;
-    if (this.lastCapturedURI) {
-      // schedule releasing the previous capture
-      setTimeout(releaseCapture, 500, this.lastCapturedURI);
-    }
-    this.lastCapturedURI = uri;
-    const {onCapture} = this.props;
-    if (onCapture) onCapture(uri);
-  };
+    // Keep latest props in refs so stable callbacks always see fresh values
+    const onCaptureRef = useRef(onCapture);
+    onCaptureRef.current = onCapture;
+    const onCaptureFailureRef = useRef(onCaptureFailure);
+    onCaptureFailureRef.current = onCaptureFailure;
+    const optionsRef = useRef(options);
+    optionsRef.current = options;
 
-  onCaptureFailure = (e: Error): void => {
-    if (!this.root) return;
-    const {onCaptureFailure} = this.props;
-    if (onCaptureFailure) onCaptureFailure(e);
-  };
+    const capture = useCallback(
+      (): Promise<string> =>
+        firstLayoutPromise
+          .then(() => {
+            if (!rootRef.current) return neverEndingPromise as Promise<never>;
+            return captureRef(rootRef.current, optionsRef.current);
+          })
+          .then(
+            uri => {
+              if (!rootRef.current) return uri;
+              if (lastCapturedURIRef.current) {
+                setTimeout(releaseCapture, 500, lastCapturedURIRef.current);
+              }
+              lastCapturedURIRef.current = uri;
+              if (onCaptureRef.current) onCaptureRef.current(uri);
+              return uri;
+            },
+            e => {
+              if (!rootRef.current) throw e;
+              if (onCaptureFailureRef.current) onCaptureFailureRef.current(e);
+              throw e;
+            },
+          ) as Promise<string>,
+      [firstLayoutPromise],
+    );
 
-  syncCaptureLoop = (captureMode: string | null | undefined): void => {
-    cancelAnimationFrame(this._raf as number);
-    if (captureMode === "continuous") {
-      let previousCaptureURI: string | null = "-"; // needs to capture at least once at first, so we use "-" arbitrary string
-      const loop = (): void => {
-        this._raf = requestAnimationFrame(loop);
-        if (previousCaptureURI === this.lastCapturedURI) return; // previous capture has not finished, don't capture yet
-        previousCaptureURI = this.lastCapturedURI;
-        this.capture();
-      };
-      this._raf = requestAnimationFrame(loop);
-    }
-  };
+    const setRootRef = useCallback(
+      (node: View | null): void => {
+        rootRef.current = node;
+        if (node) (node as ViewShotRef).capture = capture;
+        if (typeof ref === "function") {
+          ref(node as ViewShotRef | null);
+        } else if (ref) {
+          ref.current = node as ViewShotRef | null;
+        }
+      },
+      [capture, ref],
+    );
 
-  onRef = (ref: any): void => {
-    this.root = ref;
-  };
+    const syncCaptureLoop = useCallback(
+      (mode: ViewShotProperties["captureMode"] | null): void => {
+        cancelAnimationFrame(rafRef.current as number);
+        if (mode === "continuous") {
+          let previousCaptureURI: string | null = "-";
+          const loop = (): void => {
+            rafRef.current = requestAnimationFrame(loop);
+            if (previousCaptureURI === lastCapturedURIRef.current) return;
+            previousCaptureURI = lastCapturedURIRef.current;
+            capture();
+          };
+          rafRef.current = requestAnimationFrame(loop);
+        }
+      },
+      [capture],
+    );
 
-  onLayout = (e: LayoutChangeEvent): void => {
-    const {onLayout} = this.props;
-    if (this.resolveFirstLayout) {
-      this.resolveFirstLayout(e.nativeEvent.layout);
-    }
-    if (onLayout) onLayout(e);
-  };
+    useEffect(() => {
+      if (__DEV__) checkCompatibleProps(props);
+      if (captureMode === "mount") capture();
+      // Run once: re-firing on prop changes would double-trigger `mount`
+      // capture; the `[captureMode]` effect below handles loop sync, and the
+      // no-deps effect below handles `update` mode.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
-  componentDidMount(): void {
-    if (__DEV__) checkCompatibleProps(this.props);
-    if (this.props.captureMode === "mount") {
-      this.capture();
-    } else {
-      this.syncCaptureLoop(this.props.captureMode);
-    }
-  }
+    useEffect(() => {
+      syncCaptureLoop(captureMode);
+      return () => syncCaptureLoop(null);
+    }, [captureMode, syncCaptureLoop]);
 
-  componentDidUpdate(prevProps: ViewShotProperties): void {
-    if (this.props.captureMode !== undefined) {
-      if (this.props.captureMode !== prevProps.captureMode) {
-        this.syncCaptureLoop(this.props.captureMode);
+    const isFirstRender = useRef(true);
+    useEffect(() => {
+      if (isFirstRender.current) {
+        isFirstRender.current = false;
+        return;
       }
-    }
-    if (this.props.captureMode === "update") {
-      this.capture();
-    }
-  }
+      if (captureMode === "update") capture();
+    });
 
-  componentWillUnmount(): void {
-    this.syncCaptureLoop(null);
-  }
+    const onLayoutHandler = useCallback(
+      (e: LayoutChangeEvent): void => {
+        if (resolveFirstLayoutRef.current) {
+          resolveFirstLayoutRef.current(e.nativeEvent.layout);
+          resolveFirstLayoutRef.current = null;
+        }
+        if (onLayout) onLayout(e);
+      },
+      [onLayout],
+    );
 
-  render(): ReactNode {
-    const {children} = this.props;
     return (
       <View
-        ref={this.onRef}
+        ref={setRootRef}
         collapsable={false}
-        onLayout={this.onLayout}
-        style={this.props.style}
+        onLayout={onLayoutHandler}
+        style={style}
       >
         {children}
       </View>
     );
-  }
-}
+  },
+);
+
+const ViewShot = ViewShotComponent as typeof ViewShotComponent & {
+  captureRef: typeof captureRef;
+  releaseCapture: typeof releaseCapture;
+};
+ViewShot.captureRef = captureRef;
+ViewShot.releaseCapture = releaseCapture;
+
+export default ViewShot;

--- a/src/specs/NativeRNViewShot.ts
+++ b/src/specs/NativeRNViewShot.ts
@@ -1,5 +1,5 @@
 import type {TurboModule} from "react-native";
-import {TurboModuleRegistry, NativeModules, Platform} from "react-native";
+import {TurboModuleRegistry, NativeModules} from "react-native";
 import {Int32, WithDefault} from "react-native/Libraries/Types/CodegenTypes";
 
 export interface Spec extends TurboModule {


### PR DESCRIPTION
## Summary

5.0.0-alpha.2 / alpha.3 shipped broken on Android — the native module wasn't autolinked, and once linked the example app crashed in release builds. This PR bundles every fix needed so the example APK builds and runs end-to-end on the new architecture (closes #619, supersedes #618).

## What broke and why

### 1. Autolinking silently disabled (closes #619)

`package.json` has `"type": "module"` since v5, so `react-native.config.js` is loaded as ESM. The CLI loads dependency configs synchronously via `cosmiconfigSync` (`require()`):

| Node | Behavior |
|------|----------|
| 18 / 20 | `ERR_REQUIRE_ESM` → `searchResult` null → empty config → `RNViewShotPackage` not registered |
| 22 / 24 | Loads but returns `{ __esModule, default }` → wrong shape → schema validation fails → not registered |

**Fix:** rename to `react-native.config.cjs` (forces CJS regardless of `"type"`). Also fixes the dependency config schema (`dependency.platforms` instead of the app-level `project` key).

### 2. `Cannot read property 'useRef' of null` at runtime

Once autolinking worked, the app crashed inside RN core's `View_withRef` (the first forwardRef component rendered under `<ViewShot>`). Two distinct issues stacked:

**Duplicate React/React Native in the example bundle.** Metro resolved `react`/`react-native` from the lib's own `node_modules` (devDependency) AND from the example's, bundling both. With React 19, `useRef` is inlined as `ReactSharedInternals.H.useRef(...)` — only one copy of React has its dispatcher set by the renderer, so hooks called through the other copy crash on `null.useRef`. Mirrored the working `example-expo/metro.config.js`: `blockList` the parent `node_modules/{react,react-native}` and drop `../node_modules` from `nodeModulesPaths`.

**Class component lazy-loading View on the wrong thread.** Under new arch on Android, class components could trigger lazy require of RN's `View` on the `mqt_v_native` thread, which cascades to `TurboModuleRegistry.getEnforcing('PlatformConstants')` and crashes (that turbo module isn't reachable from that thread). Converted `ViewShot` to a functional component with `forwardRef` so render runs on the JS thread.

### 3. Backward compat for the v4 ref API

The functional refactor exposed `{ capture }` via `useImperativeHandle`. That broke the long-standing `captureRef(viewShotRef, opts)` usage: `findNodeHandle({capture})` throws `Argument appears to not be a ReactComponent. Keys: capture`. The forwarded ref now points to the inner `<View>` (so `findNodeHandle` walks the host tree like before) with `capture()` attached as a property on that node, so both APIs keep working:

- ✅ `captureRef(viewShotRef, opts)` and `captureRef(viewShotRef.current, opts)`
- ✅ `viewShotRef.current.capture()`

`ViewShotRef` is now `View & { capture: () => Promise<string> }`.

### 4. Metro entry point

`package.json` had `"react-native": { windows: {...} }` (a Windows platform config object) which made Metro silently fall back to `"main": "lib/index.js"` (compiled output). Set to `"src/index.tsx"`. The Windows config already lives in `react-native.config.cjs`.

### 5. CI APK build with new arch

The CI APK now builds with `-PnewArchEnabled=true`. The example's `gradle.properties` keeps `newArchEnabled=false` for Detox E2E (Fabric crashes on the emulator there).

## Files

- `react-native.config.cjs` (renamed from `.js`) — autolinking
- `package.json` — `"react-native": "src/index.tsx"`
- `example/metro.config.js` — blockList for duplicate React/RN
- `src/index.tsx` — class → functional, ref shape preserved
- `src/specs/NativeRNViewShot.ts` — drop unused import
- `.github/workflows/build-apk.yml` — `-PnewArchEnabled=true`

## Test plan

- [x] CI APK builds successfully
- [x] App opens (no `useRef of null` crash)
- [x] `Test ViewShot Capture` works (no `Argument appears to not be a ReactComponent` crash)
- [ ] Spot-check the other example screens (Modal, Video, ScrollView, SVG, FullScreen)
- [ ] Re-run iOS Detox E2E (no behavior change expected — old arch path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)