### PR TITLE
test(example): rendering correctness test card

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,17 +84,11 @@ jobs:
         working-directory: example
         run: npm ci --legacy-peer-deps
 
-      - name: Pre-build Skia Prefab packages
-        working-directory: example/android
-        run: |
-          echo "🔨 Pre-building Skia Prefab packages to avoid CMake errors..."
-          ./gradlew :shopify_react-native-skia:prefabDebugConfigurePackage --no-daemon || echo "Skia prefab not needed or already configured"
-
       - name: Build Android APK
         working-directory: example/android
         run: |
           echo "🔨 Building Android APK..."
-          ./gradlew clean assembleDebug --no-daemon --stacktrace
+          ./gradlew assembleDebug --no-daemon --stacktrace -PnewArchEnabled=true
 
       - name: Upload Android APK
         uses: actions/upload-artifact@v4

--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -8,6 +8,12 @@ module.exports = {
       setupTimeout: 300000,
     },
   },
+  artifacts: {
+    rootDir: 'artifacts',
+    plugins: {
+      screenshot: 'manual',
+    },
+  },
   apps: {
     'ios.debug': {
       type: 'ios.app',

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -27,6 +27,8 @@ export type RootStackParamList = {
   Modal: undefined;
   // Edge cases
   FS: undefined;
+  // Rendering correctness
+  Rendering: undefined;
 };
 
 // Import all test screens
@@ -42,6 +44,7 @@ import SVGUriTestScreen from './src/screens/SVGUriTestScreen';
 import ModalTestScreen from './src/screens/ModalTestScreen';
 import FSTestScreen from './src/screens/FSTestScreen';
 import ScrollViewTestScreen from './src/screens/ScrollViewTestScreen';
+import RenderingTestScreen from './src/screens/RenderingTestScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -134,6 +137,13 @@ function App(): React.JSX.Element {
           name="FS"
           component={FSTestScreen}
           options={{ title: '💾 File System Test' }}
+        />
+
+        {/* RENDERING CORRECTNESS */}
+        <Stack.Screen
+          name="Rendering"
+          component={RenderingTestScreen}
+          options={{ title: '🧪 Rendering correctness' }}
         />
       </Stack.Navigator>
     </NavigationContainer>

--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
+  plugins: ['react-native-worklets/plugin'],
 };

--- a/example/e2e/tests/viewshot-all-screens.test.js
+++ b/example/e2e/tests/viewshot-all-screens.test.js
@@ -228,4 +228,14 @@ describe('ViewShot - All Screens', () => {
       await captureScreen('Modal', '✅ Modal Captured:', 'modalScrollView');
     });
   });
+
+  describe('Rendering Correctness', () => {
+    it('should capture Rendering test card', async () => {
+      await captureScreen(
+        'Rendering test card',
+        '✅ Rendering Captured:',
+        'renderingTestScrollView',
+      );
+    });
+  });
 });

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -13,16 +13,19 @@
         "@react-navigation/native": "^7.1.33",
         "@react-navigation/native-stack": "^7.14.4",
         "@react-navigation/stack": "^7.8.4",
+        "@shopify/react-native-skia": "^2.6.2",
         "buffer": "^6.0.3",
         "react": "19.2.3",
         "react-native": "0.84.1",
         "react-native-gesture-handler": "^2.30.0",
+        "react-native-reanimated": "^4.3.0",
         "react-native-safe-area-context": "^5.7.0",
         "react-native-screens": "^4.24.0",
         "react-native-svg": "^15.15.3",
         "react-native-video": "^6.19.0",
         "react-native-view-shot": "file:..",
-        "react-native-webview": "^13.16.1"
+        "react-native-webview": "^13.16.1",
+        "react-native-worklets": "^0.8.1"
       },
       "devDependencies": {
         "@babel/core": "^7.28.4",
@@ -54,8 +57,7 @@
       }
     },
     "..": {
-      "name": "react-native-view-shot",
-      "version": "5.0.0-alpha.3",
+      "version": "5.0.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "html2canvas": "^1.4.1"
@@ -182,7 +184,6 @@
       "version": "7.27.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
       "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.27.3"
@@ -211,7 +212,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
       "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -233,7 +233,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
       "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -251,7 +250,6 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.6.tgz",
       "integrity": "sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.28.6",
@@ -277,7 +275,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
       "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.5",
@@ -321,7 +318,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
       "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.27.1"
@@ -343,7 +339,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
       "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
@@ -361,7 +356,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
       "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.28.5",
@@ -379,7 +373,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
       "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -420,7 +413,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
       "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -547,7 +539,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.27.1.tgz",
       "integrity": "sha512-hjlsMBl1aJc5lp8MoCDEZCiYzlgdRAShOjAfRw6X+GlpLpUPU7c3XNLsKFZbQk/1cRzBlJ7CXg3xJAJMrFa1Uw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -627,7 +618,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
       "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -640,7 +630,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.28.6.tgz",
       "integrity": "sha512-Svlx1fjJFnNz0LZeUaybRukSxZI3KkpApUmIRzEdXC5k8ErTOz0OD0kNrICi5Vc3GlpP5ZCeRyRO+mfWTSz+iQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -656,7 +645,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.28.6.tgz",
       "integrity": "sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -727,7 +715,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
       "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -845,7 +832,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
       "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -878,7 +864,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
       "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -894,7 +879,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
       "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -912,7 +896,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
       "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -946,7 +929,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
       "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -962,7 +944,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
       "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.28.6",
@@ -996,7 +977,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
       "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -1034,7 +1014,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
       "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -1166,7 +1145,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz",
       "integrity": "sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -1183,7 +1161,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
       "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -1299,7 +1276,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
       "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.28.6",
@@ -1352,7 +1328,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
       "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.28.5",
@@ -1385,7 +1360,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
       "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -1454,7 +1428,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
       "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -1470,7 +1443,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
       "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -1503,7 +1475,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
       "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.28.6",
@@ -1520,7 +1491,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
       "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -1554,7 +1524,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz",
       "integrity": "sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1570,7 +1539,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz",
       "integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -1606,7 +1574,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
       "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1622,7 +1589,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
       "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1655,7 +1621,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
       "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -1704,7 +1669,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.0.tgz",
       "integrity": "sha512-jlaRT5dJtMaMCV6fAuLbsQMSwz/QkvaHOHOSXRitGGwSpR1blCY4KUKoyP2tYO8vJcqYe8cEj96cqSztv3uF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -1725,7 +1689,6 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
       "integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.5",
@@ -1739,7 +1702,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
       "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1788,7 +1750,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1820,7 +1781,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
       "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -1873,7 +1833,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
       "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -2016,6 +1975,25 @@
         "@babel/plugin-transform-react-jsx": "^7.27.1",
         "@babel/plugin-transform-react-jsx-development": "^7.27.1",
         "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3956,7 +3934,6 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.84.1.tgz",
       "integrity": "sha512-vorvcvptGxtK0qTDCFQb+W3CU6oIhzcX5dduetWRBoAhXdthEQM0MQnF+GTXoXL8/luffKgy7PlZRG/WeI/oRQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
@@ -3970,7 +3947,6 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.84.1.tgz",
       "integrity": "sha512-3GpmCKk21f4oe32bKIdmkdn+WydvhhZL+1nsoFBGi30Qrq9vL16giKu31OcnWshYz139x+mVAvCyoyzgn8RXSw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -4232,7 +4208,6 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.84.1.tgz",
       "integrity": "sha512-NswINguTz0eg1Dc0oGO/1dejXSr6iQaz8/NnCRn5HJdA3dGfqadS7zlYv0YjiWpgKgcW6uENaIEgJOQww0KSpw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -4251,7 +4226,6 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.84.1.tgz",
       "integrity": "sha512-KlRawK4aXxRLlR3HYVfZKhfQp7sejQefQ/LttUWUkErhKO0AFt+yznoSLq7xwIrH9K3A3YwImHuFVtUtuDmurA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@react-native/js-polyfills": "0.84.1",
@@ -4422,6 +4396,38 @@
         "react-native-gesture-handler": ">= 2.0.0",
         "react-native-safe-area-context": ">= 4.0.0",
         "react-native-screens": ">= 4.0.0"
+      }
+    },
+    "node_modules/@shopify/react-native-skia": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-2.6.2.tgz",
+      "integrity": "sha512-NzZ3+MRedZAUhguWw9DTCpWFd09Bq+tdGWhimGfJLGckuyoWGyimTiNTmaO2DeeivHTnGdv+eXbw7j/AV3LkRQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "canvaskit-wasm": "0.41.0",
+        "react-native-skia-android": "147.1.0",
+        "react-native-skia-apple-ios": "147.1.0",
+        "react-native-skia-apple-macos": "147.1.0",
+        "react-native-skia-apple-tvos": "147.1.0",
+        "react-reconciler": "0.31.0"
+      },
+      "bin": {
+        "install-skia": "scripts/install-libs.js",
+        "setup-skia-web": "scripts/setup-canvaskit.js"
+      },
+      "peerDependencies": {
+        "react": ">=19.0",
+        "react-native": ">=0.78",
+        "react-native-reanimated": ">=3.19.1"
+      },
+      "peerDependenciesMeta": {
+        "react-native": {
+          "optional": true
+        },
+        "react-native-reanimated": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sideway/address": {
@@ -4942,6 +4948,12 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@wix-pilot/core": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/@wix-pilot/core/-/core-3.4.2.tgz",
@@ -5445,7 +5457,6 @@
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.15.tgz",
       "integrity": "sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -5474,7 +5485,6 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.6.tgz",
       "integrity": "sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.6"
@@ -5496,7 +5506,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-enums/-/babel-plugin-transform-flow-enums-0.0.2.tgz",
       "integrity": "sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-flow": "^7.12.1"
@@ -5955,6 +5964,15 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvaskit-wasm": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.41.0.tgz",
+      "integrity": "sha512-cnbL02NFB3yOYMF/MtxViZHgD1vh55Pvy+zR8q4JuFvyCPejZP3eClkt2GuZ0S7jOmGMCJXaHBasbMChbR9JZg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@webgpu/types": "0.1.21"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6343,7 +6361,6 @@
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
       "integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.1"
@@ -8576,7 +8593,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8941,7 +8957,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -9306,7 +9321,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -12842,7 +12856,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -14561,7 +14574,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -15098,6 +15110,43 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-is-edge-to-edge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.3.1.tgz",
+      "integrity": "sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-reanimated": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.3.0.tgz",
+      "integrity": "sha512-HOTTPdKtddXTOsmQxDASXEwLS3lqEHrKERD3XOgzSqWJ7L3x81Pnx7mTcKx1FKdkgomMug/XSmm1C6Z7GIowxA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.3.1",
+        "semver": "^7.7.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "0.81 - 0.85",
+        "react-native-worklets": "0.8.x"
+      }
+    },
+    "node_modules/react-native-reanimated/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/react-native-safe-area-context": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.7.0.tgz",
@@ -15121,6 +15170,30 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/react-native-skia-android": {
+      "version": "147.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-skia-android/-/react-native-skia-android-147.1.0.tgz",
+      "integrity": "sha512-pWA0M0G74AhjEop0HLCkjWJMup2HJxOmuUjfPt6kSDhYeWKVx8AEzWh0Fh19ah78zE/s4hD0Of0Tyem5shhiTg==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-skia-apple-ios": {
+      "version": "147.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-skia-apple-ios/-/react-native-skia-apple-ios-147.1.0.tgz",
+      "integrity": "sha512-cr4rWe4Bf0H0TTutUp5cgHt5/Felttl1bh4BAAAsgAeL2F10FAK9urX8spjUshzMwjqXD7rNOWuFzU6ZcNlGKw==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-skia-apple-macos": {
+      "version": "147.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-skia-apple-macos/-/react-native-skia-apple-macos-147.1.0.tgz",
+      "integrity": "sha512-Qbv0Y7LgawtRKuGk8gnGeh8nDWwNiu03LcX0mVaQzBBbxFDYvqejanA+AkO3p8gsQb+fsXRc9DAk+U8cBnzZvA==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-skia-apple-tvos": {
+      "version": "147.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-skia-apple-tvos/-/react-native-skia-apple-tvos-147.1.0.tgz",
+      "integrity": "sha512-b+4vILXHPu++t8H41PHLBVsTab2LPqwXNdzgdScyl4+Cu8Ta34aUQW3T469cB0ogAMPdu//KV00w4YVpDZoRUQ==",
+      "license": "MIT"
     },
     "node_modules/react-native-svg": {
       "version": "15.15.3",
@@ -15163,6 +15236,43 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-worklets": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.8.1.tgz",
+      "integrity": "sha512-oWP/lStsAHU6oYCaWDXrda/wOHVdhusQJz1e6x9gPnXdFf4ndNDAOtWCmk2zGrAnlapfyA3rM6PCQq94mPg9cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "^7.27.1",
+        "@babel/plugin-transform-class-properties": "^7.27.1",
+        "@babel/plugin-transform-classes": "^7.28.4",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
+        "@babel/plugin-transform-optional-chaining": "^7.27.1",
+        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
+        "@babel/plugin-transform-template-literals": "^7.27.1",
+        "@babel/plugin-transform-unicode-regex": "^7.27.1",
+        "@babel/preset-typescript": "^7.27.1",
+        "convert-source-map": "^2.0.0",
+        "semver": "^7.7.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "*",
+        "@react-native/metro-config": "*",
+        "react": "*",
+        "react-native": "0.81 - 0.85"
+      }
+    },
+    "node_modules/react-native-worklets/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native/node_modules/@jest/schemas": {
@@ -15467,6 +15577,27 @@
         }
       }
     },
+    "node_modules/react-reconciler": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
+      "integrity": "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -15540,14 +15671,12 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
       "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/regenerate-unicode-properties": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
       "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2"
@@ -15587,7 +15716,6 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
       "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2",
@@ -15605,14 +15733,12 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
       "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/regjsparser": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
       "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
-      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "jsesc": "~3.1.0"
@@ -15651,7 +15777,6 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -16798,7 +16923,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17241,7 +17365,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
       "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -17251,7 +17374,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
       "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "unicode-canonical-property-names-ecmascript": "^2.0.0",
@@ -17265,7 +17387,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
       "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -17275,7 +17396,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
       "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"

--- a/example/package.json
+++ b/example/package.json
@@ -22,16 +22,19 @@
     "@react-navigation/native": "^7.1.33",
     "@react-navigation/native-stack": "^7.14.4",
     "@react-navigation/stack": "^7.8.4",
+    "@shopify/react-native-skia": "^2.6.2",
     "buffer": "^6.0.3",
     "react": "19.2.3",
     "react-native": "0.84.1",
     "react-native-gesture-handler": "^2.30.0",
+    "react-native-reanimated": "^4.3.0",
     "react-native-safe-area-context": "^5.7.0",
     "react-native-screens": "^4.24.0",
     "react-native-svg": "^15.15.3",
     "react-native-video": "^6.19.0",
     "react-native-view-shot": "file:..",
-    "react-native-webview": "^13.16.1"
+    "react-native-webview": "^13.16.1",
+    "react-native-worklets": "^0.8.1"
   },
   "devDependencies": {
     "@babel/core": "^7.28.4",

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -96,6 +96,17 @@ const testCases: { [category: string]: TestCase[] } = {
       status: 'tested',
     },
   ],
+  '🔴 RENDERING CORRECTNESS': [
+    {
+      key: 'Rendering',
+      title: 'Rendering test card',
+      description:
+        'Transforms / nested opacity / z-index / scroll / overflow / Skia',
+      emoji: '🧪',
+      priority: 'high',
+      status: 'new',
+    },
+  ],
   '🟠 ADVANCED TESTS': [
     // {
     //   key: 'MapView',

--- a/example/src/screens/RenderingTestScreen.tsx
+++ b/example/src/screens/RenderingTestScreen.tsx
@@ -9,6 +9,9 @@ import { useViewShotCapture } from '../components/shared/hooks/useViewShotCaptur
 const CARD_WIDTH = 320;
 const CELL_GAP = 8;
 const CELL_HEIGHT = 110;
+const CARD_ROWS = 5;
+const CARD_HEIGHT =
+  CELL_HEIGHT * CARD_ROWS + CELL_GAP * CARD_ROWS + CELL_GAP * 2;
 
 interface CellProps {
   label: string;
@@ -234,7 +237,7 @@ const RenderingTestScreen: React.FC = () => {
               capturedUri={capturedUri}
               title="✅ Rendering Captured:"
               imageWidth={CARD_WIDTH}
-              imageHeight={CARD_WIDTH * 1.7}
+              imageHeight={CARD_HEIGHT}
             />
           )}
         </View>
@@ -350,6 +353,7 @@ const styles = StyleSheet.create({
     flex: 1,
     borderRadius: 4,
     backgroundColor: '#ECF0F1',
+    padding: 8,
   },
   scrolledBand: {
     height: 60,

--- a/example/src/screens/RenderingTestScreen.tsx
+++ b/example/src/screens/RenderingTestScreen.tsx
@@ -1,0 +1,389 @@
+import React, { useEffect, useRef } from 'react';
+import { View, Text, StyleSheet, SafeAreaView, ScrollView } from 'react-native';
+import ViewShot from 'react-native-view-shot';
+import { Canvas, RoundedRect, Circle } from '@shopify/react-native-skia';
+import { CaptureButton } from '../components/shared/CaptureButton';
+import { PreviewContainer } from '../components/shared/PreviewContainer';
+import { useViewShotCapture } from '../components/shared/hooks/useViewShotCapture';
+
+const CARD_WIDTH = 320;
+const CELL_GAP = 8;
+const CELL_HEIGHT = 110;
+
+interface CellProps {
+  label: string;
+  wide?: boolean;
+  children: React.ReactNode;
+}
+
+const Cell: React.FC<CellProps> = ({ label, wide, children }) => (
+  <View style={[styles.cell, wide && styles.cellWide]}>
+    <Text style={styles.cellLabel}>{label}</Text>
+    {children}
+  </View>
+);
+
+const PaddingBackgroundCell: React.FC = () => (
+  <Cell label="padding + bg + border">
+    <View style={styles.paddedBox}>
+      <View style={styles.paddedBoxInner} />
+    </View>
+  </Cell>
+);
+
+const OverflowCell: React.FC = () => (
+  <Cell label="borderRadius + overflow:hidden">
+    <View style={styles.overflowBox}>
+      <View style={styles.overflowBoxOversized} />
+    </View>
+  </Cell>
+);
+
+const TransformsRow: React.FC = () => (
+  <Cell wide label="transforms (rotate / scale / skew / 3D / combo)">
+    <View style={styles.transformRow}>
+      <View
+        style={[
+          styles.transformBox,
+          { backgroundColor: '#FF6B6B', transform: [{ rotate: '30deg' }] },
+        ]}
+      />
+      <View
+        style={[
+          styles.transformBox,
+          {
+            backgroundColor: '#4ECDC4',
+            transform: [{ scaleX: 1.4 }, { scaleY: 0.6 }],
+          },
+        ]}
+      />
+      <View
+        style={[
+          styles.transformBox,
+          { backgroundColor: '#45B7D1', transform: [{ skewX: '20deg' }] },
+        ]}
+      />
+      <View
+        style={[
+          styles.transformBox,
+          {
+            backgroundColor: '#F1C40F',
+            transform: [{ perspective: 300 }, { rotateX: '45deg' }],
+          },
+        ]}
+      />
+      <View
+        style={[
+          styles.transformBox,
+          {
+            backgroundColor: '#9B59B6',
+            transform: [
+              { translateX: 4 },
+              { rotate: '15deg' },
+              { scale: 0.85 },
+            ],
+          },
+        ]}
+      />
+    </View>
+  </Cell>
+);
+
+const NestedOpacityCell: React.FC = () => (
+  <Cell label="nested opacity (parent 0.5)">
+    <View style={styles.opacityParent}>
+      <View
+        style={[
+          styles.opacityChild,
+          { backgroundColor: '#E74C3C', left: 8, top: 8 },
+        ]}
+      />
+      <View
+        style={[
+          styles.opacityChild,
+          { backgroundColor: '#3498DB', left: 32, top: 16 },
+        ]}
+      />
+    </View>
+  </Cell>
+);
+
+const ZIndexCell: React.FC = () => (
+  <Cell label="z-index (first child on top)">
+    <View style={styles.zIndexParent}>
+      <View
+        style={[
+          styles.zIndexChild,
+          { backgroundColor: '#E74C3C', left: 0, zIndex: 3 },
+        ]}
+      />
+      <View
+        style={[
+          styles.zIndexChild,
+          { backgroundColor: '#27AE60', left: 24, zIndex: 2 },
+        ]}
+      />
+      <View
+        style={[
+          styles.zIndexChild,
+          { backgroundColor: '#3498DB', left: 48, zIndex: 1 },
+        ]}
+      />
+    </View>
+  </Cell>
+);
+
+const ScrolledCell: React.FC = () => {
+  const scrollRef = useRef<ScrollView>(null);
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      scrollRef.current?.scrollTo({ y: 60, animated: false });
+    }, 50);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <Cell wide label="scrolled ScrollView (y = 60)">
+      <ScrollView
+        ref={scrollRef}
+        style={styles.scrolledViewport}
+        scrollEnabled={false}
+      >
+        <View style={[styles.scrolledBand, { backgroundColor: '#E74C3C' }]}>
+          <Text style={styles.scrolledBandText}>top (y=0)</Text>
+        </View>
+        <View style={[styles.scrolledBand, { backgroundColor: '#F1C40F' }]}>
+          <Text style={styles.scrolledBandText}>middle (y=60)</Text>
+        </View>
+        <View style={[styles.scrolledBand, { backgroundColor: '#27AE60' }]}>
+          <Text style={styles.scrolledBandText}>bottom (y=120)</Text>
+        </View>
+      </ScrollView>
+    </Cell>
+  );
+};
+
+const SkiaCell: React.FC = () => (
+  <Cell wide label="Skia Canvas vs RN View (should match)">
+    <View style={styles.skiaRow}>
+      <View style={styles.skiaSide}>
+        <Canvas style={styles.skiaCanvas}>
+          <RoundedRect
+            x={4}
+            y={4}
+            width={56}
+            height={56}
+            r={12}
+            color="#3498DB"
+          />
+          <Circle cx={32} cy={32} r={12} color="#FFFFFF" />
+        </Canvas>
+        <Text style={styles.skiaCaption}>Skia</Text>
+      </View>
+      <View style={styles.skiaSide}>
+        <View style={styles.rnEquivalentBox}>
+          <View style={styles.rnEquivalentDot} />
+        </View>
+        <Text style={styles.skiaCaption}>RN View</Text>
+      </View>
+    </View>
+  </Cell>
+);
+
+const RenderingTestScreen: React.FC = () => {
+  const { capturedUri, isCapturing, viewShotRef, startCapture } =
+    useViewShotCapture('Rendering captured');
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={styles.scroll} testID="renderingTestScrollView">
+        <View style={styles.intro}>
+          <Text style={styles.introTitle}>🧪 Rendering correctness</Text>
+          <Text style={styles.introBody}>
+            Single capture exercising transforms, nested opacity, z-index,
+            scroll clip, padding/background, overflow:hidden, and a Skia
+            comparator. Compare iOS (ground truth) vs Android.
+          </Text>
+        </View>
+
+        <View style={styles.captureWrapper}>
+          <ViewShot ref={viewShotRef} style={styles.card}>
+            <View style={styles.row}>
+              <PaddingBackgroundCell />
+              <OverflowCell />
+            </View>
+            <TransformsRow />
+            <View style={styles.row}>
+              <NestedOpacityCell />
+              <ZIndexCell />
+            </View>
+            <ScrolledCell />
+            <SkiaCell />
+          </ViewShot>
+        </View>
+
+        <View style={styles.controls}>
+          <CaptureButton
+            onPress={() => startCapture({ format: 'png', quality: 1 })}
+            isCapturing={isCapturing}
+            captureText="📸 Capture test card"
+          />
+          {capturedUri && (
+            <PreviewContainer
+              capturedUri={capturedUri}
+              title="✅ Rendering Captured:"
+              imageWidth={CARD_WIDTH}
+              imageHeight={CARD_WIDTH * 1.7}
+            />
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#F2F2F7' },
+  scroll: { flex: 1 },
+  intro: {
+    margin: 16,
+    padding: 12,
+    backgroundColor: '#E3F2FD',
+    borderRadius: 8,
+    borderLeftWidth: 4,
+    borderLeftColor: '#1976D2',
+  },
+  introTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#0D47A1',
+    marginBottom: 4,
+  },
+  introBody: { fontSize: 12, color: '#1565C0', lineHeight: 17 },
+  captureWrapper: { alignItems: 'center', paddingVertical: 16 },
+  card: {
+    width: CARD_WIDTH,
+    backgroundColor: '#FFFFFF',
+    padding: CELL_GAP,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#DDD',
+  },
+  row: { flexDirection: 'row', gap: CELL_GAP, marginBottom: CELL_GAP },
+  cell: {
+    flex: 1,
+    height: CELL_HEIGHT,
+    backgroundColor: '#FAFAFA',
+    borderRadius: 6,
+    padding: 6,
+  },
+  cellWide: { width: '100%', flex: 0, marginBottom: CELL_GAP },
+  cellLabel: {
+    fontSize: 10,
+    fontWeight: '600',
+    color: '#555',
+    marginBottom: 4,
+  },
+
+  paddedBox: {
+    flex: 1,
+    backgroundColor: '#FFE4E1',
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: '#A52A2A',
+    padding: 10,
+  },
+  paddedBoxInner: { flex: 1, backgroundColor: '#A52A2A', borderRadius: 4 },
+
+  overflowBox: {
+    width: 120,
+    height: 70,
+    borderRadius: 24,
+    overflow: 'hidden',
+    alignSelf: 'center',
+  },
+  overflowBoxOversized: {
+    width: 200,
+    height: 120,
+    backgroundColor: '#FF7F50',
+    marginLeft: -40,
+    marginTop: -25,
+  },
+
+  transformRow: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    alignItems: 'center',
+  },
+  transformBox: { width: 32, height: 32, borderRadius: 4 },
+
+  opacityParent: {
+    flex: 1,
+    opacity: 0.5,
+    backgroundColor: '#ECF0F1',
+    borderRadius: 4,
+  },
+  opacityChild: {
+    position: 'absolute',
+    width: 48,
+    height: 48,
+    borderRadius: 4,
+  },
+
+  zIndexParent: {
+    flex: 1,
+    backgroundColor: '#ECF0F1',
+    borderRadius: 4,
+    paddingTop: 16,
+  },
+  zIndexChild: {
+    position: 'absolute',
+    top: 16,
+    width: 56,
+    height: 56,
+    borderRadius: 4,
+  },
+
+  scrolledViewport: {
+    flex: 1,
+    borderRadius: 4,
+    backgroundColor: '#ECF0F1',
+  },
+  scrolledBand: {
+    height: 60,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  scrolledBandText: { color: '#FFF', fontWeight: '700', fontSize: 12 },
+
+  skiaRow: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    alignItems: 'center',
+  },
+  skiaSide: { alignItems: 'center' },
+  skiaCanvas: { width: 64, height: 64 },
+  skiaCaption: { fontSize: 10, color: '#777', marginTop: 2 },
+  rnEquivalentBox: {
+    width: 56,
+    height: 56,
+    borderRadius: 12,
+    backgroundColor: '#3498DB',
+    margin: 4,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  rnEquivalentDot: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: '#FFFFFF',
+  },
+
+  controls: { padding: 16 },
+});
+
+export default RenderingTestScreen;


### PR DESCRIPTION
## Summary

Adds a single-capture **Rendering correctness** test card to the example app so we can back-test the Android renderer rewrite in #616 (and any future renderer changes) against a fixed visual fixture.

The card packs every dimension PR #616 touches — plus the dimensions Copilot's review questioned — into one `<ViewShot>` so a single Detox snapshot covers all of it:

- Transforms (rotate / scale / skew / 3D / combo) — full matrix path
- Nested opacity (parent 0.5 over overlapping opaque children) — Copilot's saveLayerAlpha-for-subtree concern
- z-index draw order (reversed `zIndex` on overlapping siblings) — Copilot's `getChildDrawingOrder()` concern
- Mid-scrolled `ScrollView` — Copilot's scroll/padding double-apply concern
- Padding + bg + borderRadius + border — Copilot's drawable-bounds concern
- `borderRadius` + `overflow: hidden`
- Skia `Canvas` vs RN `View` comparator — exercises the Android SurfaceView path with deterministic non-video content

## What's added

- `example/src/screens/RenderingTestScreen.tsx` — the test card. Reuses the existing `useViewShotCapture` hook + `CaptureButton` + `PreviewContainer` shared components.
- Wired into `App.tsx` + `HomeScreen.tsx` ("🔴 RENDERING CORRECTNESS" section).
- New Detox case in `example/e2e/tests/viewshot-all-screens.test.js`.
- Adds `@shopify/react-native-skia` + `react-native-reanimated` + `react-native-worklets` to the example app deps; wires `react-native-worklets/plugin` in `babel.config.js`.

iOS sim verified locally. Android verification pending CI APK build.

## Test plan

- [ ] CI generates an Android APK from this branch
- [ ] Manually open the new screen on Android and capture; visually compare against iOS
- [ ] Once iOS+Android visuals are validated, generate Detox reference snapshots with `UPDATE_SNAPSHOTS=true npm run test:e2e:{ios,android}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)