### PR TITLE
fix(android): guard applyTransformations against child == root and null parents (#488)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,12 @@ jobs:
         working-directory: example
         run: npm ci --legacy-peer-deps
 
+      - name: Run library Java unit tests
+        working-directory: example/android
+        run: |
+          echo "🧪 Running library JUnit tests..."
+          ./gradlew :react-native-view-shot:testDebugUnitTest --no-daemon --stacktrace
+
       - name: Build Android APK
         working-directory: example/android
         run: |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,12 @@ android {
       }
     }
   }
+
+  testOptions {
+    unitTests {
+      returnDefaultValues = true
+    }
+  }
 }
 
 repositories {
@@ -57,4 +63,7 @@ repositories {
 
 dependencies {
   implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
+
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.mockito:mockito-core:5.5.0'
 }

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -723,8 +723,7 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
     /**
      * Walk the parent chain from {@code child} up to (but not including)
      * {@code root}, returning the visited views in leaf-to-root order.
-     *
-     * <p>Guards against three failure modes that surfaced in #488:
+     * Guards against three failure modes that surfaced in #488:
      * <ul>
      *   <li>{@code child == root}: the captured view is itself a
      *       non-ViewGroup (e.g. a SurfaceView captured directly with
@@ -740,7 +739,7 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
      * {@code iterator.getParent()} and crashed in any of those cases.
      */
     @NonNull
-    static java.util.List<View> walkAncestors(@NonNull final View child, @NonNull final View root) {
+    static List<View> walkAncestors(@NonNull final View child, @NonNull final View root) {
         final LinkedList<View> ms = new LinkedList<>();
         if (child == root) {
             return ms;

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -721,29 +721,50 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
     }
 
     /**
+     * Walk the parent chain from {@code child} up to (but not including)
+     * {@code root}, returning the visited views in leaf-to-root order.
+     *
+     * <p>Guards against three failure modes that surfaced in #488:
+     * <ul>
+     *   <li>{@code child == root}: the captured view is itself a
+     *       non-ViewGroup (e.g. a SurfaceView captured directly with
+     *       {@code handleGLSurfaceView=true}), so {@code getAllChildren}
+     *       returns {@code [v]} and we have no ancestors to walk.</li>
+     *   <li>Null parent encountered mid-walk: the child wasn't (or no
+     *       longer is) a descendant of root.</li>
+     *   <li>Non-View {@link android.view.ViewParent} encountered (e.g.
+     *       {@code ViewRootImpl} when walking past root): casting it to
+     *       {@code View} would throw {@code ClassCastException}.</li>
+     * </ul>
+     * The original {@code do/while} loop blindly cast and dereferenced
+     * {@code iterator.getParent()} and crashed in any of those cases.
+     */
+    @NonNull
+    static java.util.List<View> walkAncestors(@NonNull final View child, @NonNull final View root) {
+        final LinkedList<View> ms = new LinkedList<>();
+        if (child == root) {
+            return ms;
+        }
+        View iterator = child;
+        while (iterator != null && iterator != root) {
+            ms.add(iterator);
+            final android.view.ViewParent parent = iterator.getParent();
+            iterator = (parent instanceof View) ? (View) parent : null;
+        }
+        return ms;
+    }
+
+    /**
      * Concat all the transformation matrix's from parent to child.
      */
     @NonNull
     @SuppressWarnings("UnusedReturnValue")
     private Matrix applyTransformations(final Canvas c, @NonNull final View root, @NonNull final View child) {
         final Matrix transform = new Matrix();
-        // When the captured view itself is the child (e.g. a SurfaceView
-        // captured directly with handleGLSurfaceView=true, where
-        // getAllChildren returns [v] for non-ViewGroups), there are no
-        // ancestor transforms to walk and the parent walk below would
-        // run past root and dereference null. See #488.
-        if (child == root) {
+        final LinkedList<View> ms = new LinkedList<>(walkAncestors(child, root));
+        if (ms.isEmpty()) {
             return transform;
         }
-        final LinkedList<View> ms = new LinkedList<>();
-
-        // find all parents of the child view
-        View iterator = child;
-        do {
-            ms.add(iterator);
-
-            iterator = (View) iterator.getParent();
-        } while (iterator != null && iterator != root);
 
         // apply transformations from parent --> child order
         Collections.reverse(ms);

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -727,6 +727,14 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
     @SuppressWarnings("UnusedReturnValue")
     private Matrix applyTransformations(final Canvas c, @NonNull final View root, @NonNull final View child) {
         final Matrix transform = new Matrix();
+        // When the captured view itself is the child (e.g. a SurfaceView
+        // captured directly with handleGLSurfaceView=true, where
+        // getAllChildren returns [v] for non-ViewGroups), there are no
+        // ancestor transforms to walk and the parent walk below would
+        // run past root and dereference null. See #488.
+        if (child == root) {
+            return transform;
+        }
         final LinkedList<View> ms = new LinkedList<>();
 
         // find all parents of the child view
@@ -735,7 +743,7 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
             ms.add(iterator);
 
             iterator = (View) iterator.getParent();
-        } while (iterator != root);
+        } while (iterator != null && iterator != root);
 
         // apply transformations from parent --> child order
         Collections.reverse(ms);

--- a/android/src/test/java/fr/greweb/reactnativeviewshot/ViewShotWalkAncestorsTest.java
+++ b/android/src/test/java/fr/greweb/reactnativeviewshot/ViewShotWalkAncestorsTest.java
@@ -1,0 +1,98 @@
+package fr.greweb.reactnativeviewshot;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Regression test for #488: walkAncestors must not throw NPE or
+ * ClassCastException when:
+ *   - child == root (captured view is itself a non-ViewGroup),
+ *   - parent chain ends in null mid-walk,
+ *   - parent chain reaches a non-View ViewParent (e.g. ViewRootImpl).
+ *
+ * Real Android view hierarchies have ViewGroup parents (which implement
+ * both View and ViewParent), so mocks here use ViewGroup for any node
+ * that needs to act as a parent.
+ */
+public class ViewShotWalkAncestorsTest {
+
+    @Test
+    public void returnsEmptyWhenChildEqualsRoot() {
+        View root = mock(View.class);
+        List<View> result = ViewShot.walkAncestors(root, root);
+        assertTrue("expected no ancestors when child == root", result.isEmpty());
+    }
+
+    @Test
+    public void stopsAtNullParent() {
+        View root = mock(View.class);
+        View child = mock(View.class);
+        when(child.getParent()).thenReturn(null);
+
+        List<View> result = ViewShot.walkAncestors(child, root);
+
+        assertEquals(1, result.size());
+        assertEquals(child, result.get(0));
+    }
+
+    @Test
+    public void stopsAtNonViewParent() {
+        View root = mock(View.class);
+        View child = mock(View.class);
+        // ViewRootImpl is a ViewParent but not a View; walking past root
+        // would hit it. Walk must stop without ClassCastException.
+        ViewParent nonView = mock(ViewParent.class);
+        when(child.getParent()).thenReturn(nonView);
+
+        List<View> result = ViewShot.walkAncestors(child, root);
+
+        assertEquals(1, result.size());
+        assertEquals(child, result.get(0));
+    }
+
+    @Test
+    public void walksUpToButNotIncludingRoot() {
+        ViewGroup root = mock(ViewGroup.class);
+        ViewGroup parent = mock(ViewGroup.class);
+        View child = mock(View.class);
+        when(child.getParent()).thenReturn(parent);
+        when(parent.getParent()).thenReturn(root);
+
+        List<View> result = ViewShot.walkAncestors(child, root);
+
+        assertEquals(2, result.size());
+        assertEquals(child, result.get(0));
+        assertEquals(parent, result.get(1));
+    }
+
+    @Test
+    public void walksDeepChainTerminatedByRoot() {
+        ViewGroup root = mock(ViewGroup.class);
+        ViewGroup g1 = mock(ViewGroup.class);
+        ViewGroup g2 = mock(ViewGroup.class);
+        ViewGroup g3 = mock(ViewGroup.class);
+        View child = mock(View.class);
+        when(child.getParent()).thenReturn(g3);
+        when(g3.getParent()).thenReturn(g2);
+        when(g2.getParent()).thenReturn(g1);
+        when(g1.getParent()).thenReturn(root);
+
+        List<View> result = ViewShot.walkAncestors(child, root);
+
+        assertEquals(4, result.size());
+        assertEquals(child, result.get(0));
+        assertEquals(g3, result.get(1));
+        assertEquals(g2, result.get(2));
+        assertEquals(g1, result.get(3));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #488. When the captured view is itself a non-`ViewGroup` (e.g. a `TextureView` or `SurfaceView` captured directly with `handleGLSurfaceView: true`), `getAllChildren(view)` returns `[view]`, so `applyTransformations(c, view, view)` is called with `child == root`.

The original parent walk:

```java
View iterator = child;
do {
    ms.add(iterator);
    iterator = (View) iterator.getParent();
} while (iterator != root);
```

never re-matches `iterator != root` (we start *at* root and walk away from it). It keeps walking up until either:

1. it dereferences a null parent and throws `NullPointerException` (the case the reporter's stack trace shows), or
2. it reaches a non-`View` `ViewParent` like `ViewRootImpl` and throws `ClassCastException` (flagged by Copilot review).

## Fix

Extract the walk into a package-private `walkAncestors(child, root)` helper that:

- short-circuits with an empty list when `child == root`,
- stops on null parent,
- stops on non-`View` `ViewParent` (`(parent instanceof View) ? (View) parent : null`).

`applyTransformations` now wraps the helper output and returns the empty matrix when there's nothing to walk.

## Test

New `android/src/test/java/.../ViewShotWalkAncestorsTest.java` covers the three failure modes with Mockito-mocked `View`/`ViewGroup`/`ViewParent` chains:

- `returnsEmptyWhenChildEqualsRoot`
- `stopsAtNullParent`
- `stopsAtNonViewParent` (the `ClassCastException` case)
- `walksUpToButNotIncludingRoot` (happy path)
- `walksDeepChainTerminatedByRoot` (multi-level happy path)

Wires `./gradlew :react-native-view-shot:testDebugUnitTest` into the existing `build-android` CI job, with `junit:4.13.2` + `mockito-core:5.5.0` as the only new `testImplementation` deps.

Diff: 4 files, +149/-15.

## Test plan

- [ ] CI runs the new JUnit suite green.
- [ ] Capture a `SurfaceView` (or any non-`ViewGroup`) directly with `handleGLSurfaceView: true` on Android — should no longer crash.
- [ ] Confirm normal nested captures still produce correct overlays for `TextureView` / `SurfaceView` children (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)