### PR TITLE
fix(ios): migrate to UIGraphicsImageRenderer for iOS 17+ compatibility (#514)

### DIFF
--- a/ios/RNViewShot.mm
+++ b/ios/RNViewShot.mm
@@ -74,7 +74,7 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
     BOOL snapshotContentContainer = [RCTConvert BOOL:options[@"snapshotContentContainer"]];
 
     // Capture image
-    BOOL success;
+    __block BOOL success = NO;
 
     UIView* rendered;
     UIScrollView* scrollView;
@@ -134,20 +134,23 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
       scrollView.frame = CGRectMake(0, 0, scrollView.contentSize.width, scrollView.contentSize.height);
     }
 
-    UIGraphicsBeginImageContextWithOptions(size, NO, 0);
-    
-    if (renderInContext) {
-      // this comes with some trade-offs such as inability to capture gradients or scrollview's content in full but it works for large views
-      [rendered.layer renderInContext: UIGraphicsGetCurrentContext()];
-      success = YES;
-    }
-    else {
-      // this doesn't work for large views and reports incorrect success even though the image is blank
-      success = [rendered drawViewHierarchyInRect:(CGRect){CGPointZero, size} afterScreenUpdates:YES];
-    }
-   
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
+    UIGraphicsImageRendererFormat *rendererFormat = [UIGraphicsImageRendererFormat preferredFormat];
+    rendererFormat.opaque = NO;
+    rendererFormat.scale = 0; // 0 means "use device scale" (matches old UIGraphicsBeginImageContextWithOptions behaviour)
+
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size format:rendererFormat];
+
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+      if (renderInContext) {
+        // this comes with some trade-offs such as inability to capture gradients or scrollview's content in full but it works for large views
+        [rendered.layer renderInContext:rendererContext.CGContext];
+        success = YES;
+      }
+      else {
+        // this doesn't work for large views and reports incorrect success even though the image is blank
+        success = [rendered drawViewHierarchyInRect:(CGRect){CGPointZero, size} afterScreenUpdates:YES];
+      }
+    }];
 
     if (snapshotContentContainer) {
       // Restore scroll & frame
@@ -161,7 +164,7 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
     }
 
     if (!image) {
-      reject(RCTErrorUnspecified, @"Failed to capture view snapshot. UIGraphicsGetImageFromCurrentImageContext() returned nil!", nil);
+      reject(RCTErrorUnspecified, @"Failed to capture view snapshot. UIGraphicsImageRenderer returned nil!", nil);
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes #514. `UIGraphicsBeginImageContextWithOptions` and friends are deprecated since iOS 17 and crash at runtime when called with `.zero` size. Replace with `UIGraphicsImageRenderer` (iOS 10+ API; lib already requires iOS 13+ via RN >=0.76).

## Changes

`ios/RNViewShot.mm`:
- Replaced `UIGraphicsBeginImageContextWithOptions` / `UIGraphicsGetCurrentContext` / `UIGraphicsGetImageFromCurrentImageContext` / `UIGraphicsEndImageContext` block with `UIGraphicsImageRenderer` + `UIGraphicsImageRendererFormat` (`opaque = NO`, `scale = 0` to preserve device-scale semantics).
- Hoisted `BOOL success` to `__block BOOL success = NO;` so it can be assigned from inside the renderer's draw block.
- Both branches preserved exactly: `useRenderInContext == YES` calls `[rendered.layer renderInContext:rendererContext.CGContext]` and forces `success = YES`; default branch still calls `drawViewHierarchyInRect:afterScreenUpdates:YES` and propagates its return value to the existing rejection.
- Surrounding logic (snapshotContentContainer save/restore, JPEG/PNG conversion on background queue, base64/data-uri/temp-file branches, error reporting) untouched.
- No changes needed in `RNViewShot.h`, the JS layer, Android, or Windows.

## Verification

- Local `xcodebuild` build of the example app: **BUILD SUCCEEDED**.
- Pre-commit hooks (`format:check`, `lint:ci`, `type-check`) all passed.

## Notes for reviewers

- The `success = YES` assignment in the `renderInContext` path is now inside a block. The drawing happens synchronously inside `imageWithActions:` (it's a synchronous API), so the value propagates correctly before the `if (!success)` check runs.
- `[UIGraphicsImageRendererFormat preferredFormat]` returns a format matching the main screen by default (P3 / sRGB depending on device). The old `UIGraphicsBeginImageContextWithOptions` produced a device-RGB context. For the vast majority of cases this is identical or better, but worth running the Detox iOS snapshot suite locally before tagging a release for color-sensitive comparisons. If a strict match is needed, `[[UIGraphicsImageRendererFormat alloc] init]` (sRGB) or explicitly setting the color space is an option.

## Test plan

- [ ] CI green (build-ios, Detox iOS).
- [ ] Test the example app on a real iOS 17+ device — the previously-crashing `UIGraphicsBeginImageContextWithOptions` path is gone.
- [ ] Confirm captures still produce expected output across the existing test screens (Rendering test card, Basic, ScrollView, etc.).
- [ ] Confirm `useRenderInContext: true` still works as a fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)