### PR TITLE
test(android): expand JUnit coverage for static/package helpers

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -340,8 +340,8 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
         promise.resolve(data);
     }
 
-    private void markSubtreeAlphaLayers(@NonNull final View v,
-                                        @NonNull final List<View> tracked) {
+    static void markSubtreeAlphaLayers(@NonNull final View v,
+                                       @NonNull final List<View> tracked) {
         if (v instanceof ViewGroup) {
             final ViewGroup group = (ViewGroup) v;
             final float alpha = v.getAlpha();
@@ -497,7 +497,7 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
     }
 
     @NonNull
-    private List<View> getAllChildren(@NonNull final View v) {
+    static List<View> getAllChildren(@NonNull final View v) {
         if (!(v instanceof ViewGroup)) {
             final ArrayList<View> viewArrayList = new ArrayList<>();
             viewArrayList.add(v);
@@ -806,7 +806,7 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
     /**
      * Propose allocation size of the array output stream.
      */
-    private static int proposeSize(@NonNull final View view) {
+    static int proposeSize(@NonNull final View view) {
         final int w = view.getWidth();
         final int h = view.getHeight();
 

--- a/android/src/test/java/fr/greweb/reactnativeviewshot/GetAllChildrenTest.java
+++ b/android/src/test/java/fr/greweb/reactnativeviewshot/GetAllChildrenTest.java
@@ -1,0 +1,146 @@
+package fr.greweb.reactnativeviewshot;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.view.View;
+import android.view.ViewGroup;
+
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Pure-Java + Mockito tests for {@link ViewShot#getAllChildren(View)} —
+ * the leaf-collection routine used to discover {@code TextureView} and
+ * {@code SurfaceView} children that need post-{@code view.draw()}
+ * compositing. Contract: only leaves (non-ViewGroup nodes) are returned;
+ * intermediate ViewGroups are not included; a non-ViewGroup root is
+ * returned as a singleton list.
+ */
+public class GetAllChildrenTest {
+
+    @Test
+    public void nonViewGroupRootIsReturnedAsSingletonList() {
+        View leaf = mock(View.class);
+
+        List<View> result = ViewShot.getAllChildren(leaf);
+
+        assertEquals(1, result.size());
+        assertSame(leaf, result.get(0));
+    }
+
+    @Test
+    public void emptyViewGroupReturnsEmptyList() {
+        ViewGroup group = mock(ViewGroup.class);
+        when(group.getChildCount()).thenReturn(0);
+
+        List<View> result = ViewShot.getAllChildren(group);
+
+        assertTrue("an empty ViewGroup must produce no leaves", result.isEmpty());
+    }
+
+    @Test
+    public void singleChildOfViewGroupReturnedAsSingletonList() {
+        ViewGroup root = mock(ViewGroup.class);
+        View child = mock(View.class);
+        when(root.getChildCount()).thenReturn(1);
+        when(root.getChildAt(0)).thenReturn(child);
+
+        List<View> result = ViewShot.getAllChildren(root);
+
+        assertEquals(1, result.size());
+        assertSame(child, result.get(0));
+    }
+
+    @Test
+    public void multipleSiblingLeavesAreReturnedInOrder() {
+        ViewGroup root = mock(ViewGroup.class);
+        View a = mock(View.class);
+        View b = mock(View.class);
+        View c = mock(View.class);
+        when(root.getChildCount()).thenReturn(3);
+        when(root.getChildAt(0)).thenReturn(a);
+        when(root.getChildAt(1)).thenReturn(b);
+        when(root.getChildAt(2)).thenReturn(c);
+
+        List<View> result = ViewShot.getAllChildren(root);
+
+        assertEquals(3, result.size());
+        assertSame(a, result.get(0));
+        assertSame(b, result.get(1));
+        assertSame(c, result.get(2));
+    }
+
+    @Test
+    public void nestedViewGroupsAreFlattenedToLeavesOnly() {
+        // root
+        //  ├─ inner (ViewGroup)
+        //  │    ├─ leafA
+        //  │    └─ leafB
+        //  └─ leafC
+        ViewGroup root = mock(ViewGroup.class);
+        ViewGroup inner = mock(ViewGroup.class);
+        View leafA = mock(View.class);
+        View leafB = mock(View.class);
+        View leafC = mock(View.class);
+
+        when(root.getChildCount()).thenReturn(2);
+        when(root.getChildAt(0)).thenReturn(inner);
+        when(root.getChildAt(1)).thenReturn(leafC);
+        when(inner.getChildCount()).thenReturn(2);
+        when(inner.getChildAt(0)).thenReturn(leafA);
+        when(inner.getChildAt(1)).thenReturn(leafB);
+
+        List<View> result = ViewShot.getAllChildren(root);
+
+        assertEquals("intermediate ViewGroups must NOT be in the result", 3, result.size());
+        assertSame(leafA, result.get(0));
+        assertSame(leafB, result.get(1));
+        assertSame(leafC, result.get(2));
+    }
+
+    @Test
+    public void deeplyNestedSingleChildChainCollectedAsOneLeaf() {
+        // root → mid → inner → leaf
+        ViewGroup root = mock(ViewGroup.class);
+        ViewGroup mid = mock(ViewGroup.class);
+        ViewGroup inner = mock(ViewGroup.class);
+        View leaf = mock(View.class);
+
+        when(root.getChildCount()).thenReturn(1);
+        when(root.getChildAt(0)).thenReturn(mid);
+        when(mid.getChildCount()).thenReturn(1);
+        when(mid.getChildAt(0)).thenReturn(inner);
+        when(inner.getChildCount()).thenReturn(1);
+        when(inner.getChildAt(0)).thenReturn(leaf);
+
+        List<View> result = ViewShot.getAllChildren(root);
+
+        assertEquals(1, result.size());
+        assertSame(leaf, result.get(0));
+    }
+
+    @Test
+    public void emptyIntermediateViewGroupContributesNoLeaves() {
+        // root
+        //  ├─ emptyGroup (ViewGroup, 0 children)
+        //  └─ leaf
+        ViewGroup root = mock(ViewGroup.class);
+        ViewGroup emptyGroup = mock(ViewGroup.class);
+        View leaf = mock(View.class);
+
+        when(root.getChildCount()).thenReturn(2);
+        when(root.getChildAt(0)).thenReturn(emptyGroup);
+        when(root.getChildAt(1)).thenReturn(leaf);
+        when(emptyGroup.getChildCount()).thenReturn(0);
+
+        List<View> result = ViewShot.getAllChildren(root);
+
+        assertEquals(1, result.size());
+        assertSame(leaf, result.get(0));
+    }
+}

--- a/android/src/test/java/fr/greweb/reactnativeviewshot/MarkSubtreeAlphaLayersTest.java
+++ b/android/src/test/java/fr/greweb/reactnativeviewshot/MarkSubtreeAlphaLayersTest.java
@@ -266,9 +266,10 @@ public class MarkSubtreeAlphaLayersTest {
     }
 
     // ---- Mockito helpers ----
-    // Static imports for any() / anyInt() avoid clutter at the top
-    // (we import them via fully-qualified calls below to dodge the
-    // import-order checkstyle).
+    // Local wrappers around Mockito ArgumentMatchers.any() / anyInt()
+    // implemented via fully-qualified calls to keep the static-import
+    // block at the top focused on org.junit.Assert / Mockito.* and avoid
+    // import-order churn.
     private static int anyInt() {
         return org.mockito.ArgumentMatchers.anyInt();
     }

--- a/android/src/test/java/fr/greweb/reactnativeviewshot/MarkSubtreeAlphaLayersTest.java
+++ b/android/src/test/java/fr/greweb/reactnativeviewshot/MarkSubtreeAlphaLayersTest.java
@@ -1,0 +1,278 @@
+package fr.greweb.reactnativeviewshot;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.view.View;
+import android.view.ViewGroup;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Pure-Java + Mockito tests for
+ * {@link ViewShot#markSubtreeAlphaLayers(View, List)} — verifies the
+ * narrow conditions under which a translucent ViewGroup is forced to
+ * {@code LAYER_TYPE_SOFTWARE} for capture, plus subtree recursion.
+ *
+ * The four ANDed conditions for marking are:
+ *   1. 0 < alpha < 1
+ *   2. childCount > 1
+ *   3. hasOverlappingRendering()
+ *   4. getLayerType() == LAYER_TYPE_NONE
+ *
+ * When all hold the view is added to the {@code tracked} list and its
+ * layer type is flipped to LAYER_TYPE_SOFTWARE. Recursion always
+ * descends into children regardless of the parent's mark eligibility.
+ */
+public class MarkSubtreeAlphaLayersTest {
+
+    /** Helper: a ViewGroup pre-stubbed for the eligibility predicate. */
+    private static ViewGroup eligibleGroup(int childCount) {
+        ViewGroup g = mock(ViewGroup.class);
+        when(g.getAlpha()).thenReturn(0.5f);
+        when(g.getChildCount()).thenReturn(childCount);
+        when(g.hasOverlappingRendering()).thenReturn(true);
+        when(g.getLayerType()).thenReturn(View.LAYER_TYPE_NONE);
+        return g;
+    }
+
+    // ---- Non-eligibility short-circuits ----
+
+    @Test
+    public void plainViewIsIgnored() {
+        View leaf = mock(View.class);
+        List<View> tracked = new ArrayList<>();
+
+        ViewShot.markSubtreeAlphaLayers(leaf, tracked);
+
+        assertTrue("non-ViewGroup must never be tracked", tracked.isEmpty());
+        verify(leaf, never()).setLayerType(anyInt(), any());
+    }
+
+    @Test
+    public void fullyOpaqueGroupIsNotMarked() {
+        ViewGroup g = eligibleGroup(2);
+        when(g.getAlpha()).thenReturn(1.0f);
+        List<View> tracked = new ArrayList<>();
+
+        ViewShot.markSubtreeAlphaLayers(g, tracked);
+
+        assertTrue(tracked.isEmpty());
+        verify(g, never()).setLayerType(anyInt(), any());
+    }
+
+    @Test
+    public void fullyTransparentGroupIsNotMarked() {
+        // alpha == 0 → still falls outside (0,1), not marked
+        ViewGroup g = eligibleGroup(2);
+        when(g.getAlpha()).thenReturn(0.0f);
+        List<View> tracked = new ArrayList<>();
+
+        ViewShot.markSubtreeAlphaLayers(g, tracked);
+
+        assertTrue(tracked.isEmpty());
+        verify(g, never()).setLayerType(anyInt(), any());
+    }
+
+    @Test
+    public void singleChildGroupIsNotMarked() {
+        // childCount == 1 → bug doesn't manifest, no layer needed
+        ViewGroup g = eligibleGroup(1);
+        // need at least one stubbed child for the recursion loop
+        View only = mock(View.class);
+        when(g.getChildAt(0)).thenReturn(only);
+        List<View> tracked = new ArrayList<>();
+
+        ViewShot.markSubtreeAlphaLayers(g, tracked);
+
+        assertTrue(tracked.isEmpty());
+        verify(g, never()).setLayerType(anyInt(), any());
+    }
+
+    @Test
+    public void zeroChildGroupIsNotMarked() {
+        ViewGroup g = eligibleGroup(0);
+        List<View> tracked = new ArrayList<>();
+
+        ViewShot.markSubtreeAlphaLayers(g, tracked);
+
+        assertTrue(tracked.isEmpty());
+        verify(g, never()).setLayerType(anyInt(), any());
+    }
+
+    @Test
+    public void groupWithoutOverlappingRenderingIsNotMarked() {
+        ViewGroup g = eligibleGroup(2);
+        when(g.hasOverlappingRendering()).thenReturn(false);
+        when(g.getChildAt(0)).thenReturn(mock(View.class));
+        when(g.getChildAt(1)).thenReturn(mock(View.class));
+        List<View> tracked = new ArrayList<>();
+
+        ViewShot.markSubtreeAlphaLayers(g, tracked);
+
+        assertTrue(tracked.isEmpty());
+        verify(g, never()).setLayerType(anyInt(), any());
+    }
+
+    @Test
+    public void groupWithExistingNonNoneLayerTypeIsNotMarked() {
+        ViewGroup g = eligibleGroup(2);
+        when(g.getLayerType()).thenReturn(View.LAYER_TYPE_HARDWARE);
+        when(g.getChildAt(0)).thenReturn(mock(View.class));
+        when(g.getChildAt(1)).thenReturn(mock(View.class));
+        List<View> tracked = new ArrayList<>();
+
+        ViewShot.markSubtreeAlphaLayers(g, tracked);
+
+        assertTrue("HARDWARE layer must not be flipped (would lose paint)", tracked.isEmpty());
+        verify(g, never()).setLayerType(anyInt(), any());
+    }
+
+    @Test
+    public void groupWithSoftwareLayerTypeIsNotReMarked() {
+        ViewGroup g = eligibleGroup(2);
+        when(g.getLayerType()).thenReturn(View.LAYER_TYPE_SOFTWARE);
+        when(g.getChildAt(0)).thenReturn(mock(View.class));
+        when(g.getChildAt(1)).thenReturn(mock(View.class));
+        List<View> tracked = new ArrayList<>();
+
+        ViewShot.markSubtreeAlphaLayers(g, tracked);
+
+        assertTrue(tracked.isEmpty());
+        verify(g, never()).setLayerType(anyInt(), any());
+    }
+
+    // ---- Eligibility happy path ----
+
+    @Test
+    public void eligibleGroupIsTrackedAndFlippedToSoftware() {
+        ViewGroup g = eligibleGroup(2);
+        when(g.getChildAt(0)).thenReturn(mock(View.class));
+        when(g.getChildAt(1)).thenReturn(mock(View.class));
+        List<View> tracked = new ArrayList<>();
+
+        ViewShot.markSubtreeAlphaLayers(g, tracked);
+
+        assertEquals(1, tracked.size());
+        assertSame(g, tracked.get(0));
+        verify(g, times(1)).setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+    }
+
+    @Test
+    public void alphaJustAboveZeroIsEligible() {
+        ViewGroup g = eligibleGroup(2);
+        when(g.getAlpha()).thenReturn(0.0001f);
+        when(g.getChildAt(0)).thenReturn(mock(View.class));
+        when(g.getChildAt(1)).thenReturn(mock(View.class));
+        List<View> tracked = new ArrayList<>();
+
+        ViewShot.markSubtreeAlphaLayers(g, tracked);
+
+        assertEquals(1, tracked.size());
+    }
+
+    @Test
+    public void alphaJustBelowOneIsEligible() {
+        ViewGroup g = eligibleGroup(2);
+        when(g.getAlpha()).thenReturn(0.9999f);
+        when(g.getChildAt(0)).thenReturn(mock(View.class));
+        when(g.getChildAt(1)).thenReturn(mock(View.class));
+        List<View> tracked = new ArrayList<>();
+
+        ViewShot.markSubtreeAlphaLayers(g, tracked);
+
+        assertEquals(1, tracked.size());
+    }
+
+    // ---- Recursion ----
+
+    @Test
+    public void recursesIntoEveryChildEvenWhenParentNotMarked() {
+        // root is opaque (childCount=2 but alpha=1), so root is NOT marked.
+        // But its eligible nested child IS.
+        ViewGroup root = mock(ViewGroup.class);
+        when(root.getAlpha()).thenReturn(1.0f);
+        when(root.getChildCount()).thenReturn(2);
+        when(root.hasOverlappingRendering()).thenReturn(true);
+        when(root.getLayerType()).thenReturn(View.LAYER_TYPE_NONE);
+
+        ViewGroup eligibleChild = eligibleGroup(2);
+        when(eligibleChild.getChildAt(0)).thenReturn(mock(View.class));
+        when(eligibleChild.getChildAt(1)).thenReturn(mock(View.class));
+        View plainChild = mock(View.class);
+
+        when(root.getChildAt(0)).thenReturn(eligibleChild);
+        when(root.getChildAt(1)).thenReturn(plainChild);
+
+        List<View> tracked = new ArrayList<>();
+
+        ViewShot.markSubtreeAlphaLayers(root, tracked);
+
+        assertEquals(1, tracked.size());
+        assertSame(eligibleChild, tracked.get(0));
+        verify(root, never()).setLayerType(anyInt(), any());
+        verify(eligibleChild, times(1)).setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+    }
+
+    @Test
+    public void marksMultipleEligibleNodesInTree() {
+        // Both root and inner are eligible — both get tracked & flipped.
+        ViewGroup root = eligibleGroup(2);
+        ViewGroup inner = eligibleGroup(2);
+        View leafA = mock(View.class);
+        View leafB = mock(View.class);
+        View leafC = mock(View.class);
+
+        when(root.getChildAt(0)).thenReturn(inner);
+        when(root.getChildAt(1)).thenReturn(leafC);
+        when(inner.getChildAt(0)).thenReturn(leafA);
+        when(inner.getChildAt(1)).thenReturn(leafB);
+
+        List<View> tracked = new ArrayList<>();
+
+        ViewShot.markSubtreeAlphaLayers(root, tracked);
+
+        assertEquals(2, tracked.size());
+        assertTrue(tracked.contains(root));
+        assertTrue(tracked.contains(inner));
+        verify(root, times(1)).setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+        verify(inner, times(1)).setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+    }
+
+    @Test
+    public void emptyTrackedListIsAcceptedAsInput() {
+        // Sanity: passing an empty list doesn't blow up, and the list
+        // is mutated in place.
+        ViewGroup g = eligibleGroup(2);
+        when(g.getChildAt(0)).thenReturn(mock(View.class));
+        when(g.getChildAt(1)).thenReturn(mock(View.class));
+
+        List<View> tracked = new ArrayList<>();
+        assertTrue(tracked.isEmpty());
+
+        ViewShot.markSubtreeAlphaLayers(g, tracked);
+
+        assertFalse(tracked.isEmpty());
+    }
+
+    // ---- Mockito helpers ----
+    // Static imports for any() / anyInt() avoid clutter at the top
+    // (we import them via fully-qualified calls below to dodge the
+    // import-order checkstyle).
+    private static int anyInt() {
+        return org.mockito.ArgumentMatchers.anyInt();
+    }
+    private static <T> T any() {
+        return org.mockito.ArgumentMatchers.<T>any();
+    }
+}

--- a/android/src/test/java/fr/greweb/reactnativeviewshot/ProposeSizeTest.java
+++ b/android/src/test/java/fr/greweb/reactnativeviewshot/ProposeSizeTest.java
@@ -1,0 +1,79 @@
+package fr.greweb.reactnativeviewshot;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.view.View;
+
+import org.junit.Test;
+
+/**
+ * Pure-Java tests for {@link ViewShot#proposeSize(View)}.
+ *
+ * The current contract is {@code Math.min(w * h * ARGB_SIZE, 32)} where
+ * ARGB_SIZE == 4 — i.e. it caps at 32 bytes, used as the seed
+ * pre-allocation for {@link ViewShot.ReusableByteArrayOutputStream}.
+ * The output stream is then grown lazily by writes.
+ */
+public class ProposeSizeTest {
+
+    private static View viewOfSize(int w, int h) {
+        View v = mock(View.class);
+        when(v.getWidth()).thenReturn(w);
+        when(v.getHeight()).thenReturn(h);
+        return v;
+    }
+
+    @Test
+    public void zeroSizedViewReturnsZero() {
+        // 0 * 0 * 4 = 0; min(0, 32) = 0
+        assertEquals(0, ViewShot.proposeSize(viewOfSize(0, 0)));
+    }
+
+    @Test
+    public void zeroWidthOrHeightReturnsZero() {
+        assertEquals(0, ViewShot.proposeSize(viewOfSize(0, 100)));
+        assertEquals(0, ViewShot.proposeSize(viewOfSize(100, 0)));
+    }
+
+    @Test
+    public void smallViewBelowCapReturnsRawArgbSize() {
+        // 2 * 2 * 4 = 16, below cap of 32
+        assertEquals(16, ViewShot.proposeSize(viewOfSize(2, 2)));
+        // 1 * 1 * 4 = 4
+        assertEquals(4, ViewShot.proposeSize(viewOfSize(1, 1)));
+    }
+
+    @Test
+    public void exactCapBoundaryReturnsCap() {
+        // 8 * 1 * 4 = 32, equals cap
+        assertEquals(32, ViewShot.proposeSize(viewOfSize(8, 1)));
+        // 4 * 2 * 4 = 32
+        assertEquals(32, ViewShot.proposeSize(viewOfSize(4, 2)));
+    }
+
+    @Test
+    public void largeViewIsCappedAtThirtyTwo() {
+        // 1080 * 1920 * 4 = 8,294,400 → capped at 32
+        assertEquals(32, ViewShot.proposeSize(viewOfSize(1080, 1920)));
+        // 100 * 100 * 4 = 40,000 → capped
+        assertEquals(32, ViewShot.proposeSize(viewOfSize(100, 100)));
+    }
+
+    @Test
+    public void integerOverflowFromMultiplicationDocumentedBehaviour() {
+        // 65536 * 65536 * 4 overflows int to 0; min(0, 32) = 0.
+        // The existing implementation does not guard against this. The
+        // test pins the current behaviour so a future change to add
+        // overflow handling is intentional and reviewed (rather than
+        // accidental). In practice the cap of 32 makes the result
+        // irrelevant at runtime — the buffer grows on first write.
+        int w = 65536;
+        int h = 65536;
+        // Sanity: confirm the multiplication overflows in int math
+        int product = w * h * 4;
+        assertEquals(0, product);
+        assertEquals(0, ViewShot.proposeSize(viewOfSize(w, h)));
+    }
+}

--- a/android/src/test/java/fr/greweb/reactnativeviewshot/ReusableByteArrayOutputStreamTest.java
+++ b/android/src/test/java/fr/greweb/reactnativeviewshot/ReusableByteArrayOutputStreamTest.java
@@ -1,0 +1,220 @@
+package fr.greweb.reactnativeviewshot;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import fr.greweb.reactnativeviewshot.ViewShot.ReusableByteArrayOutputStream;
+
+/**
+ * Pure-Java tests for {@link ReusableByteArrayOutputStream} — exercises
+ * the buffer-grow path, capacity edge cases, and the {@code asBuffer}
+ * lazy-grow contract used by RAW captures.
+ *
+ * MAX_ARRAY_SIZE is private but mirrors {@code Integer.MAX_VALUE - 8}
+ * (matching the JDK convention). Tests reference that literal directly.
+ */
+public class ReusableByteArrayOutputStreamTest {
+
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+    /** Test subclass that exposes the protected grow() to assertions. */
+    private static class TestStream extends ReusableByteArrayOutputStream {
+        TestStream(byte[] buffer) {
+            super(buffer);
+        }
+        void callGrow(int minCapacity) {
+            grow(minCapacity);
+        }
+    }
+
+    // ---- innerBuffer / setSize / constructor ----
+
+    @Test
+    public void innerBufferReturnsSameInstanceAsConstructor() {
+        byte[] buffer = new byte[16];
+        ReusableByteArrayOutputStream s = new ReusableByteArrayOutputStream(buffer);
+        assertSame("inner buffer must be the exact instance passed in", buffer, s.innerBuffer());
+    }
+
+    @Test
+    public void setSizeUpdatesCountWithoutResizingBuffer() {
+        byte[] buffer = new byte[16];
+        ReusableByteArrayOutputStream s = new ReusableByteArrayOutputStream(buffer);
+
+        s.setSize(7);
+        assertEquals(7, s.size());
+        // setSize must not resize the underlying buffer
+        assertSame(buffer, s.innerBuffer());
+
+        s.setSize(0);
+        assertEquals(0, s.size());
+    }
+
+    @Test
+    public void setSizeAcceptsValueLargerThanBufferLengthWithoutThrowing() {
+        // setSize is purely a count mutation — it does not (and is not
+        // expected to) validate against the buffer length. Documenting
+        // that contract: the caller is responsible for ensuring the
+        // buffer is large enough before reading 'size' bytes back.
+        ReusableByteArrayOutputStream s = new ReusableByteArrayOutputStream(new byte[4]);
+        s.setSize(99);
+        assertEquals(99, s.size());
+    }
+
+    // ---- asBuffer ----
+
+    @Test
+    public void asBufferReturnsByteBufferWrappingInnerBufferWhenLargeEnough() {
+        byte[] buffer = new byte[32];
+        ReusableByteArrayOutputStream s = new ReusableByteArrayOutputStream(buffer);
+
+        ByteBuffer bb = s.asBuffer(16);
+
+        assertNotNull(bb);
+        // ByteBuffer.wrap exposes the same backing array
+        assertTrue("byte buffer should expose the inner array", bb.hasArray());
+        assertSame(buffer, bb.array());
+        // No grow happened
+        assertSame(buffer, s.innerBuffer());
+        assertEquals(buffer.length, bb.capacity());
+    }
+
+    @Test
+    public void asBufferGrowsBufferWhenRequestedSizeExceedsCurrentCapacity() {
+        byte[] buffer = new byte[8];
+        ReusableByteArrayOutputStream s = new ReusableByteArrayOutputStream(buffer);
+
+        ByteBuffer bb = s.asBuffer(64);
+
+        assertTrue("capacity should have grown to at least 64", bb.capacity() >= 64);
+        assertTrue("inner buffer should reflect the grown size",
+                s.innerBuffer().length >= 64);
+        // grow doubles first; if doubling is enough we keep that, else use minCapacity.
+        // 8 << 1 = 16 < 64, so newCapacity = 64.
+        assertEquals(64, s.innerBuffer().length);
+    }
+
+    @Test
+    public void asBufferIsNoOpWhenRequestedSizeEqualsCurrentLength() {
+        byte[] buffer = new byte[16];
+        ReusableByteArrayOutputStream s = new ReusableByteArrayOutputStream(buffer);
+
+        ByteBuffer bb = s.asBuffer(16);
+
+        // 16 < 16 is false → no grow
+        assertSame(buffer, s.innerBuffer());
+        assertEquals(16, bb.capacity());
+    }
+
+    // ---- grow ----
+
+    @Test
+    public void growDoublesCapacityWhenDoublingSatisfiesMinCapacity() {
+        TestStream s = new TestStream(new byte[16]);
+
+        s.callGrow(20); // 16 << 1 = 32, 32 >= 20 → use 32
+
+        assertEquals(32, s.innerBuffer().length);
+    }
+
+    @Test
+    public void growUsesMinCapacityWhenDoublingIsTooSmall() {
+        TestStream s = new TestStream(new byte[8]);
+
+        s.callGrow(100); // 8 << 1 = 16 < 100 → use 100
+
+        assertEquals(100, s.innerBuffer().length);
+    }
+
+    @Test
+    public void growPreservesExistingBufferContents() {
+        byte[] initial = new byte[]{1, 2, 3, 4};
+        TestStream s = new TestStream(initial);
+
+        s.callGrow(64);
+
+        byte[] grown = s.innerBuffer();
+        assertEquals(64, grown.length);
+        assertEquals(1, grown[0]);
+        assertEquals(2, grown[1]);
+        assertEquals(3, grown[2]);
+        assertEquals(4, grown[3]);
+        assertEquals(0, grown[4]);
+    }
+
+    @Test
+    public void growHandlesMinCapacityEqualToZero() {
+        // Edge case: minCapacity == 0. oldCapacity (4) << 1 == 8, and
+        // 8 - 0 < 0 is false, so newCapacity stays at 8. Verifies the
+        // doubling branch doesn't accidentally shrink to minCapacity.
+        TestStream s = new TestStream(new byte[4]);
+
+        s.callGrow(0);
+
+        assertEquals(8, s.innerBuffer().length);
+    }
+
+    @Test
+    public void growHandlesSmallStartingBuffer() {
+        // 1-byte buffer, doubling to 2 satisfies minCapacity=2.
+        TestStream s = new TestStream(new byte[1]);
+
+        s.callGrow(2);
+
+        assertEquals(2, s.innerBuffer().length);
+    }
+
+    // ---- hugeCapacity ----
+
+    @Test
+    public void hugeCapacityThrowsOnNegativeMinCapacity() {
+        try {
+            ReusableByteArrayOutputStream.hugeCapacity(-1);
+            fail("expected OutOfMemoryError on negative input");
+        } catch (OutOfMemoryError expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void hugeCapacityThrowsOnIntegerMinValueOverflow() {
+        try {
+            ReusableByteArrayOutputStream.hugeCapacity(Integer.MIN_VALUE);
+            fail("expected OutOfMemoryError on Integer.MIN_VALUE");
+        } catch (OutOfMemoryError expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void hugeCapacityReturnsMaxArraySizeForExactBoundary() {
+        // minCapacity == MAX_ARRAY_SIZE → not greater than → returns MAX_ARRAY_SIZE
+        assertEquals(MAX_ARRAY_SIZE,
+                ReusableByteArrayOutputStream.hugeCapacity(MAX_ARRAY_SIZE));
+    }
+
+    @Test
+    public void hugeCapacityReturnsMaxArraySizeWhenMinCapacityFitsBelowBoundary() {
+        assertEquals(MAX_ARRAY_SIZE,
+                ReusableByteArrayOutputStream.hugeCapacity(MAX_ARRAY_SIZE - 1));
+        assertEquals(MAX_ARRAY_SIZE,
+                ReusableByteArrayOutputStream.hugeCapacity(0));
+        assertEquals(MAX_ARRAY_SIZE,
+                ReusableByteArrayOutputStream.hugeCapacity(1));
+    }
+
+    @Test
+    public void hugeCapacityReturnsIntegerMaxValueWhenMinCapacityExceedsMaxArraySize() {
+        assertEquals(Integer.MAX_VALUE,
+                ReusableByteArrayOutputStream.hugeCapacity(MAX_ARRAY_SIZE + 1));
+        assertEquals(Integer.MAX_VALUE,
+                ReusableByteArrayOutputStream.hugeCapacity(Integer.MAX_VALUE));
+    }
+}

--- a/android/src/test/java/fr/greweb/reactnativeviewshot/ViewShotStateMachineTest.java
+++ b/android/src/test/java/fr/greweb/reactnativeviewshot/ViewShotStateMachineTest.java
@@ -16,10 +16,10 @@ import org.junit.Test;
  * Tests pinning the contract of the
  * {@code STATE_QUEUED / STATE_RUNNING / STATE_DONE} state machine and
  * the {@link ViewShot.UiThreadBlockTimeoutException}. The CAS protocol
- * in {@code runOnUiThreadBlocking} relies on:
- *  - distinct numeric values for each state,
- *  - QUEUED == 0 (matches {@code AtomicInteger} default initial value
- *    used at construction).
+ * in {@code runOnUiThreadBlocking} relies only on equality (via
+ * {@code compareAndSet}), so these tests assert the three states are
+ * pairwise distinct so the CAS protocol can distinguish them — nothing
+ * more. Numeric values and ordering are deliberately not pinned.
  *
  * Constants are private; we read them via reflection rather than
  * widening their visibility.
@@ -43,29 +43,6 @@ public class ViewShotStateMachineTest {
         assertNotEquals("QUEUED == RUNNING would break CAS", queued, running);
         assertNotEquals("RUNNING == DONE would break CAS", running, done);
         assertNotEquals("QUEUED == DONE would break CAS", queued, done);
-    }
-
-    @Test
-    public void queuedIsZeroToMatchAtomicIntegerDefault() throws Exception {
-        // AtomicInteger is constructed with no initial value in the
-        // current code (state.compareAndSet(STATE_QUEUED, ...)), which
-        // requires QUEUED == 0 — the default int. Even though the
-        // current source uses an explicit constructor argument, this
-        // test pins the contract should that detail change.
-        assertEquals(0, readPrivateStaticInt("STATE_QUEUED"));
-    }
-
-    @Test
-    public void stateConstantsAreOrdered() throws Exception {
-        int queued = readPrivateStaticInt("STATE_QUEUED");
-        int running = readPrivateStaticInt("STATE_RUNNING");
-        int done = readPrivateStaticInt("STATE_DONE");
-
-        // QUEUED → RUNNING → DONE is the lifecycle direction; numeric
-        // ordering documents that intent (even though the CAS itself
-        // doesn't compare ordinals).
-        assertTrue("QUEUED should precede RUNNING", queued < running);
-        assertTrue("RUNNING should precede DONE", running < done);
     }
 
     // ---- UiThreadBlockTimeoutException ----

--- a/android/src/test/java/fr/greweb/reactnativeviewshot/ViewShotStateMachineTest.java
+++ b/android/src/test/java/fr/greweb/reactnativeviewshot/ViewShotStateMachineTest.java
@@ -1,0 +1,124 @@
+package fr.greweb.reactnativeviewshot;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.junit.Test;
+
+/**
+ * Tests pinning the contract of the
+ * {@code STATE_QUEUED / STATE_RUNNING / STATE_DONE} state machine and
+ * the {@link ViewShot.UiThreadBlockTimeoutException}. The CAS protocol
+ * in {@code runOnUiThreadBlocking} relies on:
+ *  - distinct numeric values for each state,
+ *  - QUEUED == 0 (matches {@code AtomicInteger} default initial value
+ *    used at construction).
+ *
+ * Constants are private; we read them via reflection rather than
+ * widening their visibility.
+ */
+public class ViewShotStateMachineTest {
+
+    private static int readPrivateStaticInt(String name) throws Exception {
+        Field f = ViewShot.class.getDeclaredField(name);
+        f.setAccessible(true);
+        assertTrue("expected static field: " + name, Modifier.isStatic(f.getModifiers()));
+        assertTrue("expected final field: " + name, Modifier.isFinal(f.getModifiers()));
+        return f.getInt(null);
+    }
+
+    @Test
+    public void stateConstantsAreDistinct() throws Exception {
+        int queued = readPrivateStaticInt("STATE_QUEUED");
+        int running = readPrivateStaticInt("STATE_RUNNING");
+        int done = readPrivateStaticInt("STATE_DONE");
+
+        assertNotEquals("QUEUED == RUNNING would break CAS", queued, running);
+        assertNotEquals("RUNNING == DONE would break CAS", running, done);
+        assertNotEquals("QUEUED == DONE would break CAS", queued, done);
+    }
+
+    @Test
+    public void queuedIsZeroToMatchAtomicIntegerDefault() throws Exception {
+        // AtomicInteger is constructed with no initial value in the
+        // current code (state.compareAndSet(STATE_QUEUED, ...)), which
+        // requires QUEUED == 0 — the default int. Even though the
+        // current source uses an explicit constructor argument, this
+        // test pins the contract should that detail change.
+        assertEquals(0, readPrivateStaticInt("STATE_QUEUED"));
+    }
+
+    @Test
+    public void stateConstantsAreOrdered() throws Exception {
+        int queued = readPrivateStaticInt("STATE_QUEUED");
+        int running = readPrivateStaticInt("STATE_RUNNING");
+        int done = readPrivateStaticInt("STATE_DONE");
+
+        // QUEUED → RUNNING → DONE is the lifecycle direction; numeric
+        // ordering documents that intent (even though the CAS itself
+        // doesn't compare ordinals).
+        assertTrue("QUEUED should precede RUNNING", queued < running);
+        assertTrue("RUNNING should precede DONE", running < done);
+    }
+
+    // ---- UiThreadBlockTimeoutException ----
+
+    @Test
+    public void uiThreadBlockTimeoutExceptionIsRuntimeException() {
+        ViewShot.UiThreadBlockTimeoutException e =
+                new ViewShot.UiThreadBlockTimeoutException("hello");
+
+        assertTrue("must extend RuntimeException so it propagates without checked-throws",
+                e instanceof RuntimeException);
+    }
+
+    @Test
+    public void uiThreadBlockTimeoutExceptionMessageRoundTrips() {
+        ViewShot.UiThreadBlockTimeoutException e =
+                new ViewShot.UiThreadBlockTimeoutException("Timed out waiting for UI thread after 5s");
+
+        assertEquals("Timed out waiting for UI thread after 5s", e.getMessage());
+    }
+
+    @Test
+    public void uiThreadBlockTimeoutExceptionAcceptsNullMessage() {
+        ViewShot.UiThreadBlockTimeoutException e =
+                new ViewShot.UiThreadBlockTimeoutException(null);
+
+        assertNull(e.getMessage());
+    }
+
+    @Test
+    public void uiThreadBlockTimeoutExceptionAcceptsEmptyMessage() {
+        ViewShot.UiThreadBlockTimeoutException e =
+                new ViewShot.UiThreadBlockTimeoutException("");
+
+        assertNotNull(e.getMessage());
+        assertEquals("", e.getMessage());
+    }
+
+    @Test
+    public void uiThreadBlockTimeoutExceptionCanBeThrownAndCaughtAsItself() {
+        try {
+            throw new ViewShot.UiThreadBlockTimeoutException("boom");
+        } catch (ViewShot.UiThreadBlockTimeoutException caught) {
+            assertEquals("boom", caught.getMessage());
+        }
+    }
+
+    @Test
+    public void uiThreadBlockTimeoutExceptionCanBeCaughtAsRuntimeException() {
+        try {
+            throw new ViewShot.UiThreadBlockTimeoutException("boom");
+        } catch (RuntimeException caught) {
+            assertSame(ViewShot.UiThreadBlockTimeoutException.class, caught.getClass());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Expands JUnit + Mockito coverage for the pure-Java / static parts of `ViewShot.java` that don't require Robolectric. Brings total test count from 5 to **55** (+50 tests across 5 new files) — all pass on the existing `build-android` CI step (`./gradlew :react-native-view-shot:testDebugUnitTest`).

## What's covered

- **`ReusableByteArrayOutputStreamTest`** (16 tests) — `innerBuffer`, `setSize`, `asBuffer` lazy-grow, `grow` doubling vs. min-capacity branch, `hugeCapacity` boundary cases (negative-overflow OOM, `MAX_ARRAY_SIZE` exact boundary, `Integer.MAX_VALUE` return).
- **`ProposeSizeTest`** (6 tests) — zero-sized views, sub-cap, exact 32-byte boundary, large views, int-overflow behaviour pinning.
- **`GetAllChildrenTest`** (7 tests) — non-`ViewGroup` root, empty group, nested flattening, deep single-child chain, mixed leaves, empty intermediate group.
- **`MarkSubtreeAlphaLayersTest`** (14 tests) — each of the four ANDed conditions (alpha bounds, childCount, hasOverlappingRendering, layerType), happy path, recursion into non-eligible parents.
- **`ViewShotStateMachineTest`** (7 tests, reflection-based) — `STATE_QUEUED/RUNNING/DONE` are pairwise distinct (the CAS protocol relies on equality, nothing more), `UiThreadBlockTimeoutException` is a `RuntimeException`, message round-trip + null/empty handling, throw/catch hierarchy. Numeric values and ordering of the state constants are deliberately **not** pinned so the implementation can refactor them freely.

## Source change (minimal, no logic edits)

`android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java`:
- `markSubtreeAlphaLayers`: `private` → package-private + `static` (didn't reference `this`)
- `getAllChildren`: `private` → package-private + `static` (didn't reference `this`)
- `proposeSize`: `private static` → package-private `static`

All call-sites resolve unchanged because the methods are invoked bare-name from inside `ViewShot`. No behaviour changes.

## Test results

```
55 tests, 0 failures, 0 errors
BUILD SUCCESSFUL in 16s
```

Pre-commit hooks (prettier / eslint / tsc) all pass.

## Considered but skipped (out of scope for pure JUnit)

- `runOnUiThreadBlocking` — needs Looper / Handler runtime; cannot drive the latch + CAS state-machine without Robolectric.
- `applyTransformations` (post parent-walk body) — touches `Canvas` / `Matrix` whose methods are stubbed under the unit-test JVM.
- `captureViewImpl` / `executeImpl` / bitmap-pool helpers — drive `Bitmap.createBitmap`, `view.draw()`, `bitmap.compress`, `Deflater`, `Base64`, `Promise`, `ReactApplicationContext`. Real-runtime / integration-test territory.

## Test plan

- [ ] CI green (`build-android` job runs the new tests via `./gradlew :react-native-view-shot:testDebugUnitTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)