### PR TITLE
feat(example): style filters repro screen (#578)

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -29,6 +29,7 @@ export type RootStackParamList = {
   FS: undefined;
   // Rendering correctness
   Rendering: undefined;
+  StyleFilters: undefined;
 };
 
 // Import all test screens
@@ -45,6 +46,7 @@ import ModalTestScreen from './src/screens/ModalTestScreen';
 import FSTestScreen from './src/screens/FSTestScreen';
 import ScrollViewTestScreen from './src/screens/ScrollViewTestScreen';
 import RenderingTestScreen from './src/screens/RenderingTestScreen';
+import StyleFiltersTestScreen from './src/screens/StyleFiltersTestScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -144,6 +146,11 @@ function App(): React.JSX.Element {
           name="Rendering"
           component={RenderingTestScreen}
           options={{ title: '🧪 Rendering correctness' }}
+        />
+        <Stack.Screen
+          name="StyleFilters"
+          component={StyleFiltersTestScreen}
+          options={{ title: '🎨 Style filters (Bug #578)' }}
         />
       </Stack.Navigator>
     </NavigationContainer>

--- a/example/e2e/tests/style-filters.test.js
+++ b/example/e2e/tests/style-filters.test.js
@@ -1,0 +1,57 @@
+/**
+ * Style filters repro test (#578)
+ *
+ * Navigates to the Style filters screen, taps capture and asserts the
+ * preview wrapper becomes visible. This is a sanity test only — it
+ * exercises the path so the screen doesn't break silently. There is
+ * no pixel-snapshot reference because the captured output is currently
+ * unfiltered (which is the bug we're tracking).
+ */
+
+const { goHome, scrollToElement } = require('../helpers/test-actions');
+
+describe('ViewShot - Style filters (#578)', () => {
+  beforeAll(async () => {
+    await device.launchApp({
+      newInstance: true,
+      permissions: { photos: 'YES', camera: 'YES' },
+      launchArgs: { detoxEnableSynchronization: 0 },
+    });
+
+    await waitFor(element(by.text('🚀 React Native ViewShot')))
+      .toBeVisible()
+      .withTimeout(60000);
+  });
+
+  it('captures the filtered card and shows the (unfiltered) preview', async () => {
+    await goHome();
+
+    // Home menu uses `nav-${title.toLowerCase().replace(/\s+/g, '-')}`.
+    // The screen title is "Style filters".
+    await scrollToElement(by.id('nav-style-filters'), 'homeScrollView');
+    await element(by.id('nav-style-filters')).tap();
+
+    await waitFor(element(by.id('styleFiltersTestScrollView')))
+      .toBeVisible()
+      .withTimeout(10000);
+
+    // The card sits below the intro card; scroll until the capture button shows.
+    await scrollToElement(
+      by.id('capture-button'),
+      'styleFiltersTestScrollView',
+    );
+
+    // Sanity check: the section wrapper should also be present.
+    await expect(element(by.id('styleFilters-section'))).toExist();
+
+    // Tap capture and wait for the preview wrapper to appear.
+    await element(by.id('capture-button')).tap();
+
+    await waitFor(element(by.id('styleFilters-preview')))
+      .toBeVisible()
+      .withTimeout(15000);
+
+    // Take a CI artifact screenshot for visual inspection.
+    await device.takeScreenshot('style_filters');
+  });
+});

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -106,6 +106,15 @@ const testCases: { [category: string]: TestCase[] } = {
       priority: 'high',
       status: 'new',
     },
+    {
+      key: 'StyleFilters',
+      title: 'Style filters',
+      description:
+        'RN `filter` prop (brightness/contrast/blur/...) — known gap (#578)',
+      emoji: '🎨',
+      priority: 'high',
+      status: 'bug',
+    },
   ],
   '🟠 ADVANCED TESTS': [
     // {

--- a/example/src/screens/StyleFiltersTestScreen.tsx
+++ b/example/src/screens/StyleFiltersTestScreen.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  ViewStyle,
+} from 'react-native';
+import ViewShot from 'react-native-view-shot';
+import { CaptureButton } from '../components/shared/CaptureButton';
+import { PreviewContainer } from '../components/shared/PreviewContainer';
+import { useViewShotCapture } from '../components/shared/hooks/useViewShotCapture';
+
+const CARD_WIDTH = 320;
+const CELL_GAP = 8;
+const CELL_HEIGHT = 110;
+const CARD_ROWS = 5; // 9 cells in a 2-col grid + small slack
+const CARD_HEIGHT =
+  CELL_HEIGHT * CARD_ROWS + CELL_GAP * CARD_ROWS + CELL_GAP * 2;
+
+/**
+ * The "source" rendered inside every cell. We use a solid colored block with
+ * a couple of inner shapes so each filter has something visible to alter
+ * (saturation, hue rotation, etc.). No remote image — keeps the Detox test
+ * fast and deterministic.
+ */
+const FilterSource: React.FC = () => (
+  <View style={styles.source}>
+    <View style={[styles.sourceStripe, { backgroundColor: '#E74C3C' }]} />
+    <View style={[styles.sourceStripe, { backgroundColor: '#F1C40F' }]} />
+    <View style={[styles.sourceStripe, { backgroundColor: '#27AE60' }]} />
+    <View style={[styles.sourceStripe, { backgroundColor: '#3498DB' }]} />
+    <View style={styles.sourceDot} />
+  </View>
+);
+
+interface FilterCellProps {
+  label: string;
+  filter?: ViewStyle['filter'];
+}
+
+const FilterCell: React.FC<FilterCellProps> = ({ label, filter }) => (
+  <View style={styles.cell}>
+    <Text style={styles.cellLabel}>{label}</Text>
+    <View style={styles.cellInner}>
+      <View style={filter ? { flex: 1, filter } : styles.fill}>
+        <FilterSource />
+      </View>
+    </View>
+  </View>
+);
+
+const StyleFiltersTestScreen: React.FC = () => {
+  const { capturedUri, isCapturing, viewShotRef, startCapture } =
+    useViewShotCapture('StyleFilters captured');
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={styles.scroll} testID="styleFiltersTestScrollView">
+        <View style={styles.intro}>
+          <Text style={styles.introTitle}>🎨 Style filters (#578)</Text>
+          <Text style={styles.introBody}>
+            RN&apos;s `filter` style prop covers brightness, contrast,
+            grayscale, hueRotate, invert, saturate, sepia, blur, dropShadow. The
+            capture-time gap differs by platform:
+          </Text>
+          <Text style={styles.introBullet}>
+            • <Text style={styles.introBold}>iOS</Text>: every filter renders
+            live via `CALayer.filters`. Matrix-based filters (brightness /
+            contrast / grayscale / hueRotate / invert / saturate / sepia) modify
+            the layer&apos;s content directly and DO appear in the capture.
+            CIFilter-based effects (blur, dropShadow) are applied
+            post-composition and `drawViewHierarchyInRect` /
+            `UIGraphicsImageRenderer` don&apos;t see them — those are the true
+            #578 gap on iOS.
+          </Text>
+          <Text style={styles.introBullet}>
+            • <Text style={styles.introBold}>Android</Text>: RN&apos;s runtime
+            only wires `brightness` (and a couple others depending on version).
+            Most filters don&apos;t even render live, so the capture matches the
+            live (unfiltered) result — there&apos;s no demonstrable capture gap
+            here, the limitation is upstream RN.
+          </Text>
+        </View>
+
+        <View style={styles.captureWrapper} testID="styleFilters-section">
+          <ViewShot ref={viewShotRef} style={styles.card}>
+            <View style={styles.row}>
+              <FilterCell label="no filter (reference)" />
+              <FilterCell
+                label="brightness(1.5)"
+                filter={[{ brightness: 1.5 }]}
+              />
+            </View>
+            <View style={styles.row}>
+              <FilterCell label="contrast(1.8)" filter={[{ contrast: 1.8 }]} />
+              <FilterCell label="grayscale(1)" filter={[{ grayscale: 1 }]} />
+            </View>
+            <View style={styles.row}>
+              <FilterCell
+                label="hueRotate(90deg)"
+                filter={[{ hueRotate: '90deg' }]}
+              />
+              <FilterCell label="invert(1)" filter={[{ invert: 1 }]} />
+            </View>
+            <View style={styles.row}>
+              <FilterCell label="saturate(2)" filter={[{ saturate: 2 }]} />
+              <FilterCell label="sepia(1)" filter={[{ sepia: 1 }]} />
+            </View>
+            <View style={styles.row}>
+              <FilterCell label="blur(8)" filter={[{ blur: 8 }]} />
+              <FilterCell label="(empty)" />
+            </View>
+          </ViewShot>
+        </View>
+
+        <View style={styles.controls}>
+          <CaptureButton
+            onPress={() => startCapture({ format: 'png', quality: 1 })}
+            isCapturing={isCapturing}
+            captureText="📸 Capture filtered card"
+          />
+          {capturedUri && (
+            <View testID="styleFilters-preview">
+              <PreviewContainer
+                capturedUri={capturedUri}
+                title="✅ Style Filters Captured:"
+                noteText="iOS: blur/dropShadow are missing (true gap). Android: most filters never rendered live, so capture matches live."
+                imageWidth={CARD_WIDTH}
+                imageHeight={CARD_HEIGHT}
+              />
+            </View>
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#F2F2F7' },
+  scroll: { flex: 1 },
+  intro: {
+    margin: 16,
+    padding: 12,
+    backgroundColor: '#FDECEA',
+    borderRadius: 8,
+    borderLeftWidth: 4,
+    borderLeftColor: '#C0392B',
+  },
+  introTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#7B1F12',
+    marginBottom: 4,
+  },
+  introBody: { fontSize: 12, color: '#922B21', lineHeight: 17 },
+  introBullet: {
+    fontSize: 12,
+    color: '#922B21',
+    lineHeight: 17,
+    marginTop: 6,
+  },
+  introBold: { fontWeight: '700' },
+  captureWrapper: { alignItems: 'center', paddingVertical: 16 },
+  card: {
+    width: CARD_WIDTH,
+    backgroundColor: '#FFFFFF',
+    padding: CELL_GAP,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#DDD',
+  },
+  row: { flexDirection: 'row', gap: CELL_GAP, marginBottom: CELL_GAP },
+  cell: {
+    flex: 1,
+    height: CELL_HEIGHT,
+    backgroundColor: '#FAFAFA',
+    borderRadius: 6,
+    padding: 6,
+  },
+  cellLabel: {
+    fontSize: 10,
+    fontWeight: '600',
+    color: '#555',
+    marginBottom: 4,
+  },
+  cellInner: {
+    flex: 1,
+    overflow: 'hidden',
+    borderRadius: 4,
+    backgroundColor: '#ECF0F1',
+  },
+  fill: { flex: 1 },
+  source: { flex: 1, flexDirection: 'row', position: 'relative' },
+  sourceStripe: { flex: 1, height: '100%' },
+  sourceDot: {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    width: 24,
+    height: 24,
+    marginLeft: -12,
+    marginTop: -12,
+    borderRadius: 12,
+    backgroundColor: '#FFFFFF',
+    borderWidth: 2,
+    borderColor: '#2C3E50',
+  },
+  controls: { padding: 16 },
+});
+
+export default StyleFiltersTestScreen;


### PR DESCRIPTION
## Summary

Adds a reproducible example for issue #578 (\"Result doesn't account style filters\").

RN's `filter` style prop (`brightness`, `contrast`, `grayscale`, `hueRotate`, `invert`, `saturate`, `sepia`, `blur`, `dropShadow`) is applied at composite-time by the native renderer (Android `RenderEffect` API 31+, iOS `CALayer.filters`). The capture path uses a software canvas (`view.draw()` on Android, `drawViewHierarchyInRect` / `renderInContext` on iOS) which bypasses these filters, so the captured image shows the unfiltered source.

This PR does **not** address #578 — it makes the gap reproducible so a future PR can close the issue.

### What's in this PR
- New screen `example/src/screens/StyleFiltersTestScreen.tsx` showing 9 cells (one per filter + a no-filter reference) inside a `<ViewShot>` test card. After tapping capture, the unfiltered preview is rendered below the live (filtered) card so the visual gap is obvious.
- Wired into `example/App.tsx` navigation as `StyleFilters`, and listed under \"🔴 RENDERING CORRECTNESS\" on the home screen with `status: 'bug'`.
- Detox E2E sanity test `example/e2e/tests/style-filters.test.js` that navigates to the screen, taps capture and asserts the preview wrapper becomes visible. No pixel-snapshot reference (the captured output is intentionally wrong).

### Filters demonstrated
All 9 filters supported by RN 0.84's `FilterFunction` type (per `StyleSheetTypes.d.ts`):
`brightness(1.5)`, `contrast(1.8)`, `grayscale(1)`, `hueRotate(90deg)`, `invert(1)`, `saturate(2)`, `sepia(1)`, `blur(8)`, plus a no-filter reference cell. `dropShadow` was omitted to keep the cell grid uniform; the others alone make the rendering gap obvious.

## Screenshots
Screenshots TBD — needs running on device/simulator. The Detox CI run will produce a `style_filters` artifact screenshot for visual inspection.

## Test plan
- [ ] iOS sim: open the app → \"Style filters\" → tap capture → confirm the captured image looks unfiltered while the live card is filtered.
- [ ] Android emu: same as above (filters require API 31+).
- [ ] `npm run build:e2e:ios && npm run test:e2e:ios -- e2e/tests/style-filters.test.js` passes.
- [ ] Inspect CI artifact screenshot `style_filters` to visually confirm the gap.

Refs #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)