### PR TITLE
docs(ios): explain style.filter blur/dropShadow capture gap (#578)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,23 @@ A prop may be necessary to properly capture GL Surface View in the view tree:
 handleGLSurfaceViewOnAndroid?: boolean;
 ```
 
+### `style.filter` (`blur`, `dropShadow`, …) is missing from the capture? (iOS)
+
+> Tracked in [#578](https://github.com/gre/react-native-view-shot/issues/578).
+
+React Native renders `style.filter` effects on iOS through a SwiftUI host view (`UIHostingController`) gated by the upstream `enableSwiftUIBasedFilters` feature flag. The native capture path used by this library — `drawViewHierarchyInRect:afterScreenUpdates:` (default) and `CALayer.renderInContext:` (when `useRenderInContext: true`) — captures the underlying view hierarchy, not the SwiftUI compositor's post-composition output, so:
+
+- `brightness` (and `opacity`) are part of the layer's contents and **do** appear in the capture.
+- `blur` and `dropShadow` are SwiftUI-only effects applied above the layer hierarchy and are **not** captured. There is currently no public iOS API that re-renders a `UIHostingController`'s effect chain into a context.
+- `grayscale`, `saturate`, `contrast`, `hueRotate`, `invert`, `sepia` go through SwiftUI as well when the feature flag is on; whether they survive `drawViewHierarchyInRect` depends on the iOS version and the SwiftUI runtime.
+
+A repro screen exercising every supported filter ships with the example app at `example/src/screens/StyleFiltersTestScreen.tsx`.
+
+**Workarounds:**
+
+- Apply the visual effect via a layer that participates in the regular view hierarchy (e.g. a translucent overlay for shadows, a pre-blurred image asset, or a third-party native blur view that draws into its `CALayer.contents`). Those compose into the capture normally.
+- If you only need a single full-frame blur on the captured image, post-process the resulting `UIImage` yourself with `CIGaussianBlur`. Per-element blur is not addressable from outside the SwiftUI compositor.
+
 ### Trying to share the capture result with `expo-sharing`?
 
 `tmpfile` or the default capture result works best for this. Just be sure to prepend `file://` to result before you call `shareAsync`.

--- a/example/src/screens/StyleFiltersTestScreen.tsx
+++ b/example/src/screens/StyleFiltersTestScreen.tsx
@@ -66,14 +66,17 @@ const StyleFiltersTestScreen: React.FC = () => {
             capture-time gap differs by platform:
           </Text>
           <Text style={styles.introBullet}>
-            • <Text style={styles.introBold}>iOS</Text>: every filter renders
-            live via `CALayer.filters`. Matrix-based filters (brightness /
-            contrast / grayscale / hueRotate / invert / saturate / sepia) modify
-            the layer&apos;s content directly and DO appear in the capture.
-            CIFilter-based effects (blur, dropShadow) are applied
-            post-composition and `drawViewHierarchyInRect` /
-            `UIGraphicsImageRenderer` don&apos;t see them — those are the true
-            #578 gap on iOS.
+            • <Text style={styles.introBold}>iOS</Text>: filters are rendered by
+            React Native through a SwiftUI `UIHostingController` (gated by
+            upstream `enableSwiftUIBasedFilters`). `brightness` is applied via a
+            sibling `compositingFilter` layer and DOES survive the capture.
+            `blur` / `dropShadow` are SwiftUI post-composition effects and are
+            NOT reproduced by `drawViewHierarchyInRect` or
+            `CALayer.renderInContext` — that is the #578 gap. Other filters
+            (grayscale / saturate / contrast / hueRotate / invert / sepia) go
+            through the same SwiftUI path and may render inconsistently
+            depending on the iOS / RN version. See README → Troubleshooting →
+            "`style.filter` is missing from the capture?" for workarounds.
           </Text>
           <Text style={styles.introBullet}>
             • <Text style={styles.introBold}>Android</Text>: RN&apos;s runtime
@@ -126,7 +129,7 @@ const StyleFiltersTestScreen: React.FC = () => {
               <PreviewContainer
                 capturedUri={capturedUri}
                 title="✅ Style Filters Captured:"
-                noteText="iOS: blur/dropShadow are missing (true gap). Android: most filters never rendered live, so capture matches live."
+                noteText="iOS: blur/dropShadow are missing (SwiftUI compositor — see README #578). Android: most filters never rendered live, so capture matches live."
                 imageWidth={CARD_WIDTH}
                 imageHeight={CARD_HEIGHT}
               />

--- a/ios/RNViewShot.mm
+++ b/ios/RNViewShot.mm
@@ -150,6 +150,12 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
         // this doesn't work for large views and reports incorrect success even though the image is blank
         success = [rendered drawViewHierarchyInRect:(CGRect){CGPointZero, size} afterScreenUpdates:YES];
       }
+      // Known limitation (#578): React Native renders `style.filter` effects
+      // (notably `blur` and `dropShadow`) through a SwiftUI `UIHostingController`
+      // that lives above the layer hierarchy. Neither `drawViewHierarchyInRect`
+      // nor `CALayer.renderInContext` reproduce the SwiftUI compositor's
+      // post-composition output, so those filters are missing from the capture.
+      // See README "Troubleshooting / FAQ" and `example/src/screens/StyleFiltersTestScreen.tsx`.
     }];
 
     if (snapshotContentContainer) {


### PR DESCRIPTION
## Summary

- Documents why `style.filter` effects (`blur`, `dropShadow`, …) on iOS don't survive the capture: RN renders them through a SwiftUI `UIHostingController` (gated by upstream `enableSwiftUIBasedFilters`) that lives above the layer hierarchy, so neither `drawViewHierarchyInRect:` nor `CALayer.renderInContext:` see the compositor output.
- Adds a Troubleshooting entry in the README with workarounds (matrix-based filters, pre-composition into an image).
- Leaves a 6-line pointer comment in `ios/RNViewShot.mm` so future maintainers land on the rationale.
- Tightens the StyleFilters repro screen wording (was based on a `CALayer.filters` hypothesis that doesn't match upstream RN's actual mechanism).

No behaviour change.

Closes one of the documentation asks on #578; the underlying capture gap remains a platform-level limitation.

## Test plan

- [x] `npm run lint`, `npm run type-check`, `prettier --check` all green
- [x] Pre-commit hook passed
- [ ] Visual check on the StyleFilters repro screen wording (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)