### PR TITLE
chore(deps): bump transitive deps in example-windows lockfile

### DIFF
--- a/example-windows/package-lock.json
+++ b/example-windows/package-lock.json
@@ -26,7 +26,7 @@
     },
     "..": {
       "name": "react-native-view-shot",
-      "version": "5.0.0-alpha.3",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "html2canvas": "^1.4.1"
@@ -2020,41 +2020,41 @@
       }
     },
     "node_modules/@microsoft/1ds-core-js": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.3.10.tgz",
-      "integrity": "sha512-5fSZmkGwWkH+mrIA5M1GYPZdPM+SjXwCCl2Am7VhFoVwOBJNhRnwvIpAdzw6sFjiebN/rz+/YH0NdxztGZSa9Q==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.4.1.tgz",
+      "integrity": "sha512-utqwacfUkiGJROn4WC7aNdRBsRxwhNWXuqaJM2B0N0WHmv1+IhSuI7RQ3FHwxRP1dxZi/xn9aELMZ7HMStsW1w==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "node_modules/@microsoft/1ds-post-js": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.3.10.tgz",
-      "integrity": "sha512-VSLjc9cT+Y+eTiSfYltJHJCejn8oYr0E6Pq2BMhOEO7F6IyLGYIxzKKvo78ze9x+iHX7KPTATcZ+PFgjGXuNqg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.4.1.tgz",
+      "integrity": "sha512-CkFEhDY7X8E2JLr6HsEvRiC0DaLOCsA7vlbq/9DJP65gAumgw2NnFNIAOg6Je5Geq1LDu76/nb2hP34p8eGggw==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/1ds-core-js": "4.3.10",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.3.10.tgz",
-      "integrity": "sha512-5yKeyassZTq2l+SAO4npu6LPnbS++UD+M+Ghjm9uRzoBwD8tumFx0/F8AkSVqbniSREd+ztH/2q2foewa2RZyg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+      "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       },
       "peerDependencies": {
         "tslib": ">= 1.0.0"
@@ -2079,18 +2079,18 @@
       }
     },
     "node_modules/@nevware21/ts-async": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.4.tgz",
-      "integrity": "sha512-IBTyj29GwGlxfzXw2NPnzty+w0Adx61Eze1/lknH/XIVdxtF9UnOpk76tnrHXWa6j84a1RR9hsOcHQPFv9qJjA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
+      "integrity": "sha512-vwqaL05iJPjLeh5igPi8MeeAu10i+Aq7xko1fbo9F5Si6MnVN5505qaV7AhSdk5MCBJVT/UYMk3kgInNjDb4Ig==",
       "license": "MIT",
       "dependencies": {
-        "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x"
       }
     },
     "node_modules/@nevware21/ts-utils": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.12.5.tgz",
-      "integrity": "sha512-JPQZWPKQJjj7kAftdEZL0XDFfbMgXCGiUAZe0d7EhLC3QlXTlZdSckGqqRIQ2QNl0VTEZyZUvRBw6Ednw089Fw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.13.0.tgz",
+      "integrity": "sha512-F3mD+DsUn9OiZmZc5tg0oKqrJCtiCstwx+wE+DNzFYh2cCRUuzTYdK9zGGP/au2BWvbOQ6Tqlbjr2+dT1P3AlQ==",
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2638,9 +2638,9 @@
       }
     },
     "node_modules/@react-native-windows/cli": {
-      "version": "0.75.10",
-      "resolved": "https://registry.npmjs.org/@react-native-windows/cli/-/cli-0.75.10.tgz",
-      "integrity": "sha512-mOWlu/O+bAKJOWAhrr4AZzL3Tr++E26C0jEYrusBW9f7WOIydi5/jllxTIlix7BQtWQ9qgJ+ugfBJC+LApjQpw==",
+      "version": "0.75.11",
+      "resolved": "https://registry.npmjs.org/@react-native-windows/cli/-/cli-0.75.11.tgz",
+      "integrity": "sha512-kryQu3qZl17XrcTdlas/uZ63U26NfDvM39V34NrmagEsrMbr3oqHNAbxj7lwDm+X+VFSGl+6MxO5hWdbMCkbSg==",
       "license": "MIT",
       "dependencies": {
         "@react-native-windows/codegen": "0.75.7",
@@ -2876,9 +2876,9 @@
       }
     },
     "node_modules/@react-native-windows/cli/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3507,7 +3507,7 @@
       "version": "0.7.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
       "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
-      "deprecated": "this version is no longer supported, please update to at least 0.8.*",
+      "deprecated": "this version has critical issues, please update to the latest version",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4577,9 +4577,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz",
-      "integrity": "sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
+      "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
       "funding": [
         {
           "type": "github",
@@ -5640,9 +5640,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -6420,9 +6420,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -6905,9 +6905,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -7047,9 +7047,9 @@
       "link": true
     },
     "node_modules/react-native-windows": {
-      "version": "0.75.19",
-      "resolved": "https://registry.npmjs.org/react-native-windows/-/react-native-windows-0.75.19.tgz",
-      "integrity": "sha512-20QKT5t7fuOyMmDkgjM7tbdJ1zkNV0/fL+nOnrPabpJ3rkg7YqRh4jKD1sgu2YNZUjoRnz/iht3ErIVqxucrwg==",
+      "version": "0.75.20",
+      "resolved": "https://registry.npmjs.org/react-native-windows/-/react-native-windows-0.75.20.tgz",
+      "integrity": "sha512-OvxkSWIn2njOzTJSQYCCg7h8xDmrkf4ZCO48/jEVvsmCNiiiQ7/LSNySMqo5kLMF8meBOwPphF5iSXmW8g1BiA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
@@ -7057,7 +7057,7 @@
         "@react-native-community/cli": "14.1.0",
         "@react-native-community/cli-platform-android": "14.1.0",
         "@react-native-community/cli-platform-ios": "14.1.0",
-        "@react-native-windows/cli": "0.75.10",
+        "@react-native-windows/cli": "0.75.11",
         "@react-native/assets": "1.0.0",
         "@react-native/assets-registry": "0.75.5",
         "@react-native/codegen": "0.75.5",
@@ -8646,7 +8646,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
@@ -8862,15 +8862,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {


### PR DESCRIPTION
## Summary

- Triages the 23 open Dependabot alerts on the repo. All 23 are in example apps (demo/dev tooling) — the published library (root `package.json`) has zero alerts.
- Applies non-breaking `npm audit fix` (no `--force`) on `example-windows/package-lock.json` only. All upgrades are patch/minor bumps to transitive dependencies:
  - `fast-xml-parser` 4.5.4 → 4.5.6 (high)
  - `lodash` 4.17.23 → 4.18.1 (high + medium)
  - `node-forge` 1.3.3 → 1.4.0 (high, ×4)
  - `yaml` 2.8.1 → 2.8.4 (medium)
  - Plus incidental patch bumps (`@react-native-community/cli-*`, `@microsoft/1ds-*`, `react-native-windows` 0.75.19 → 0.75.20).

## Side-effect: workspace link version sync

`npm install` also re-read the root `package.json` and resynced the `file:..` link of `react-native-view-shot` in the lockfile from `5.0.0-alpha.3` → `5.0.1` (the lockfile was stale; root has been at `5.0.1` for a while). This isn't a dep bump per se — it just realigns the example with reality.

Pre-existing consequence: the library peers `react-native >=0.76.0` while `example-windows` is on `react-native@0.75.4` (gated by RNW 0.75.x). Installing `example-windows` already required `--legacy-peer-deps`/`--force` before this PR; the lockfile change makes that situation visible rather than introducing it. Real fix is bumping RNW to a major that ships with RN ≥ 0.76, tracked separately.

## Skipped (require major bumps — handled separately or dismissable)

| Bloc | Unblocks |
|---|---|
| `react-native-windows` 0.75 → 1.0 | `@xmldom/xmldom` (×5), `uuid` <14, `fast-xml-parser` 5.x |
| `expo` ~46 → 49+ (example-expo) | ~10 alerts (`uuid`, `postcss`) |
| `webpack-dev-server` major (example-web) | `uuid` |
| `jest-junit` 16 → 17 (example/) | `uuid` |

None of the remaining alerts touch the published library — they could also be dismissed as "tolerable risk – dev/example-only" via the Dependabot UI.

## Test plan

- [x] Root `npm run build`, `npm run lint`, `npm run type-check` all green
- [x] Pre-commit hook passed
- [ ] Optional: `example-windows` build verification on a Windows host
