### PR TITLE
ci(windows): real build + dotnet unit tests, fix autolink discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,13 @@ jobs:
           }
           Write-Host "OK: $exe and RNViewShot.winmd present"
 
+      - name: Upload Windows app package
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-app
+          path: example-windows/windows/ViewShotWindowsExample/AppPackages/**
+          if-no-files-found: error
+
       - name: Upload Windows build logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
 
   test-windows-unit:
     name: Run Windows unit tests
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: lint-and-type-check
 
     steps:
@@ -207,8 +207,26 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('windows/RNViewShot.Tests/RNViewShot.Tests.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
       - name: Run dotnet tests
-        run: dotnet test windows/RNViewShot.Tests/RNViewShot.Tests.csproj --nologo --verbosity normal
+        run: |
+          dotnet test windows/RNViewShot.Tests/RNViewShot.Tests.csproj \
+            --nologo --verbosity normal \
+            --logger "trx;LogFileName=test-results.trx" \
+            --results-directory TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-unit-test-results
+          path: TestResults/
 
   build-windows:
     name: Build Windows
@@ -224,6 +242,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            example-windows/package-lock.json
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
@@ -232,6 +253,13 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-build-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: ${{ runner.os }}-nuget-build-
 
       - name: Install root dependencies
         run: npm install --legacy-peer-deps
@@ -256,6 +284,7 @@ jobs:
             --no-launch `
             --no-deploy `
             --no-packager `
+            --no-autolink `
             --logging `
             --buildLogDirectory buildlogs `
             --no-telemetry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,23 @@ jobs:
           name: ios-build-logs
           path: ~/Library/Logs/DiagnosticReports/
 
+  test-windows-unit:
+    name: Run Windows unit tests
+    runs-on: windows-latest
+    needs: lint-and-type-check
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Run dotnet tests
+        run: dotnet test windows/RNViewShot.Tests/RNViewShot.Tests.csproj --nologo --verbosity normal
+
   build-windows:
     name: Build Windows
     runs-on: windows-latest
@@ -211,6 +228,11 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Install root dependencies
         run: npm install --legacy-peer-deps
 
@@ -221,189 +243,36 @@ jobs:
         working-directory: example-windows
         run: npm ci --legacy-peer-deps
 
-      - name: Verify parent library is available
-        working-directory: example-windows
-        shell: pwsh
-        run: |
-          Write-Host "🔍 Verifying parent library setup..."
-          
-          # Check if parent library was built
-          if (Test-Path "../lib") {
-            Write-Host "✅ Parent library built (lib/ exists)"
-            Get-ChildItem "../lib" | Select-Object Name
-          } else {
-            Write-Host "❌ Parent library not built (lib/ missing)"
-          }
-          
-          # Check if parent Windows module exists
-          if (Test-Path "../windows") {
-            Write-Host "✅ Parent Windows module exists"
-            Get-ChildItem "../windows" | Select-Object Name
-          } else {
-            Write-Host "❌ Parent Windows module missing"
-          }
-          
-          # Check if react-native.config.js exists in parent
-          if (Test-Path "../react-native.config.js") {
-            Write-Host "✅ Parent react-native.config.js exists"
-            Get-Content "../react-native.config.js"
-          } else {
-            Write-Host "❌ Parent react-native.config.js missing"
-          }
-          
-          # Check node_modules for react-native-view-shot
-          if (Test-Path "node_modules/react-native-view-shot") {
-            Write-Host "✅ react-native-view-shot in node_modules"
-            Get-ChildItem "node_modules/react-native-view-shot" | Select-Object Name
-          } else {
-            Write-Host "❌ react-native-view-shot not in node_modules"
-          }
-
       - name: Run Windows autolinking
         working-directory: example-windows
-        shell: pwsh
-        continue-on-error: true
-        run: |
-          Write-Host "🔗 Running React Native Windows autolinking..."
-          npx react-native autolink-windows --logging --verbose
-          
-          Write-Host ""
-          Write-Host "📋 Checking autolinking results..."
-          if (Test-Path "windows/ViewShotWindowsExample/AutolinkedNativeModules.g.cpp") {
-            $content = Get-Content "windows/ViewShotWindowsExample/AutolinkedNativeModules.g.cpp" -Raw
-            Write-Host "Autolinking file generated (length: $($content.Length) chars)"
-            Write-Host "First 500 chars:"
-            Write-Host $content.Substring(0, [Math]::Min(500, $content.Length))
-            if ($content -match "ViewShot" -or $content -match "RNViewShot") {
-              Write-Host "✅ ViewShot module found in autolinking!"
-            } else {
-              Write-Host "⚠️  ViewShot not in autolinking, but build will continue"
-            }
-          } else {
-            Write-Host "❌ Autolinking file not found!"
-          }
-          
-          Write-Host ""
-          Write-Host "📁 Checking parent library location..."
-          if (Test-Path "../react-native.config.js") {
-            Write-Host "✅ Found react-native.config.js in parent"
-            Get-Content "../react-native.config.js" | Select-Object -First 15
-          }
-          if (Test-Path "../package.json") {
-            Write-Host "✅ Found ../package.json"
-            $packageJson = Get-Content "../package.json" | ConvertFrom-Json
-            if ($packageJson.'react-native'.windows) {
-              Write-Host "✅ Windows config found in parent package.json"
-              $packageJson.'react-native'.windows | ConvertTo-Json
-            } else {
-              Write-Host "⚠️  No Windows config in parent package.json"
-            }
-          }
-          if (Test-Path "../windows") {
-            Write-Host "✅ Found ../windows directory"
-            Get-ChildItem "../windows" | Select-Object Name
-          }
+        run: npx --no-install react-native autolink-windows --no-telemetry
 
-      - name: Check autolinking results
-        working-directory: example-windows/windows/ViewShotWindowsExample
+      - name: Build example-windows
+        working-directory: example-windows
         shell: pwsh
         run: |
-          Write-Host "🔍 Checking autolinking results..."
-          
-          if (Test-Path "AutolinkedNativeModules.g.cs") {
-            $content = Get-Content "AutolinkedNativeModules.g.cs" -Raw
-            Write-Host "AutolinkedNativeModules.g.cs content:"
-            Write-Host $content
-            
-            if ($content -match "ViewShot" -or $content -match "RNViewShot") {
-              Write-Host "✅ ViewShot module found in autolinking!"
-            } else {
-              Write-Host "⚠️  ViewShot module NOT found in autolinking"
-              Write-Host "This might be why the build fails - the module isn't being linked"
-            }
-          } else {
-            Write-Host "❌ AutolinkedNativeModules.g.cs not found"
-          }
-          
-          Write-Host ""
-          Write-Host "Checking solution file for module references..."
-          $slnContent = Get-Content "../ViewShotWindowsExample.sln" -Raw
-          if ($slnContent -match "RNViewShot") {
-            Write-Host "✅ RNViewShot referenced in solution file"
-          } else {
-            Write-Host "⚠️  RNViewShot NOT referenced in solution file"
-          }
+          npx --no-install react-native run-windows `
+            --arch x64 `
+            --no-launch `
+            --no-deploy `
+            --no-packager `
+            --logging `
+            --buildLogDirectory buildlogs `
+            --no-telemetry
 
-      - name: Restore NuGet packages
-        working-directory: example-windows/windows
-        continue-on-error: true
-        run: nuget restore ViewShotWindowsExample.sln
-
-      - name: Build Windows example app
-        working-directory: example-windows/windows
+      - name: Verify build artifacts
+        working-directory: example-windows
         shell: pwsh
         run: |
-          Write-Host "🔨 Building Windows UWP app..."
-          Write-Host "Current directory: $PWD"
-          Write-Host "Solution file exists: $(Test-Path ViewShotWindowsExample.sln)"
-          
-          # Check if RNViewShot project exists
-          if (Test-Path "..\..\windows\RNViewShot\RNViewShot.csproj") {
-            Write-Host "✅ RNViewShot project found"
-          } else {
-            Write-Host "⚠️  RNViewShot project not found, building without it"
+          $exe = "windows/ViewShotWindowsExample/bin/x64/Debug/ViewShotWindowsExample.exe"
+          $rnviewshot = "windows/ViewShotWindowsExample/bin/x64/Debug/RNViewShot.winmd"
+          if (-not (Test-Path $exe)) {
+            Write-Error "Missing $exe"; exit 1
           }
-          
-          Write-Host ""
-          Write-Host "⚠️  Windows build is temporarily disabled due to CI issues"
-          Write-Host "Windows support is under construction - see example-windows/README.md for details"
-          Write-Host "The Windows build fails due to missing React Native Windows assemblies in CI"
-          Write-Host "This is a known issue that will be resolved separately"
-          
-          # Skip the actual build for now
-          Write-Host "✅ Windows build step completed (disabled - under construction)"
-
-      - name: Verify Windows build artifacts
-        working-directory: example-windows/windows
-        shell: pwsh
-        run: |
-          Write-Host "✅ Checking build artifacts..."
-          $buildPath = "x64/Debug/ViewShotWindowsExample"
-          
-          if (Test-Path $buildPath) {
-            Write-Host "✅ Build directory exists"
-            Get-ChildItem $buildPath -Recurse | Select-Object -First 10 | ForEach-Object {
-              Write-Host "   - $($_.Name)"
-            }
-          } else {
-            Write-Warning "Build directory not found at expected location"
+          if (-not (Test-Path $rnviewshot)) {
+            Write-Error "Missing $rnviewshot — RNViewShot module did not link"; exit 1
           }
-          
-          Write-Host "✅ Windows build verification complete"
-
-      - name: Verify ViewShot native module inclusion
-        working-directory: example-windows/windows/ViewShotWindowsExample
-        shell: pwsh
-        run: |
-          Write-Host "🔍 Verifying ViewShot module is included in build..."
-          
-          # Check autogenerated files
-          if (Test-Path "AutolinkedNativeModules.g.cpp") {
-            $content = Get-Content "AutolinkedNativeModules.g.cpp" -Raw
-            if ($content -match "RNViewShot" -or $content -match "ViewShot") {
-              Write-Host "✅ ViewShot module found in AutolinkedNativeModules.g.cpp"
-            } else {
-              Write-Warning "⚠️  ViewShot module not found in autolinking (might be manual)"
-            }
-          }
-          
-          # Check solution file for module reference
-          $slnContent = Get-Content "../ViewShotWindowsExample.sln" -Raw
-          if ($slnContent -match "RNViewShot") {
-            Write-Host "✅ RNViewShot referenced in solution file"
-          }
-          
-          Write-Host "✅ ViewShot module verification complete"
+          Write-Host "OK: $exe and RNViewShot.winmd present"
 
       - name: Upload Windows build logs
         if: failure()
@@ -411,7 +280,7 @@ jobs:
         with:
           name: windows-build-logs
           path: |
-            example-windows/windows/*.log
+            example-windows/buildlogs/**
             example-windows/windows/**/*.log
             example-windows/windows/**/*.err
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,13 +257,35 @@ jobs:
       - name: Ensure Windows SDK 10.0.22621
         shell: pwsh
         run: |
-          if (Test-Path "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0") {
+          $sdkPath = "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0"
+          if (Test-Path $sdkPath) {
             Write-Host "Windows SDK 10.0.22621 already installed"
-          } else {
-            Write-Host "Installing Windows SDK 10.0.22621 via winget"
-            winget install --id Microsoft.WindowsSDK.10.0.22621 `
-              --silent --accept-package-agreements --accept-source-agreements
+            exit 0
           }
+          Write-Host "Installed SDKs:"
+          Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\Include" -ErrorAction SilentlyContinue | Select-Object Name | ForEach-Object { Write-Host "  $($_.Name)" }
+
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $info = & $vswhere -latest -prerelease -products * -format json | ConvertFrom-Json
+          if (-not $info) { throw "vswhere returned no VS install" }
+          Write-Host "VS productId: $($info.productId)"
+
+          $vsInstaller = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
+          $args = @(
+            'modify',
+            '--channelId', $info.channelId,
+            '--productId', $info.productId,
+            '--add', 'Microsoft.VisualStudio.Component.Windows11SDK.22621',
+            '--quiet', '--norestart'
+          )
+          Write-Host "Running: $vsInstaller $($args -join ' ')"
+          $proc = Start-Process -FilePath $vsInstaller -ArgumentList $args -Wait -PassThru
+          Write-Host "vs_installer exit code: $($proc.ExitCode)"
+
+          if (-not (Test-Path $sdkPath)) {
+            throw "Windows SDK 10.0.22621 still missing after install attempt"
+          }
+          Write-Host "Windows SDK 10.0.22621 installed"
 
       - name: Cache NuGet packages
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,17 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Ensure Windows SDK 10.0.22621
+        shell: pwsh
+        run: |
+          if (Test-Path "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0") {
+            Write-Host "Windows SDK 10.0.22621 already installed"
+          } else {
+            Write-Host "Installing Windows SDK 10.0.22621 via winget"
+            winget install --id Microsoft.WindowsSDK.10.0.22621 `
+              --silent --accept-package-agreements --accept-source-agreements
+          }
+
       - name: Cache NuGet packages
         uses: actions/cache@v4
         with:

--- a/example-windows/README.md
+++ b/example-windows/README.md
@@ -1,45 +1,27 @@
-# Windows Example - Minimal ViewShot Test
+# Windows Example
 
-This is a minimal React Native Windows app to test the ViewShot module.
+React Native Windows demo app for `react-native-view-shot`.
 
-## ⚠️ Current Status
+## Prerequisites
 
-**Windows support is currently under construction and not working in CI.**
-
-The Windows build fails in GitHub Actions CI due to missing React Native Windows assemblies and dependencies. This is a known issue that needs to be resolved separately from the main CI pipeline.
-
-**Current CI Status:**
-
-- ✅ All other platforms (Android, iOS, Web) work correctly
-- ❌ Windows build is temporarily disabled in CI
-- 🔧 Windows support is being worked on separately
-
-## Setup
-
-```bash
-npm install
-npx react-native-windows-init --overwrite
-```
+- Node 20+
+- Visual Studio 2022 with the **Universal Windows Platform development** and **Native desktop with C++** workloads
+- Windows 11 SDK 10.0.22621
+- .NET 8 SDK on `PATH`
 
 ## Run
 
 ```bash
-npm run windows
+cd example-windows
+npm install --legacy-peer-deps
+npx react-native autolink-windows
+npx react-native run-windows --arch x64
 ```
 
-## Test
+`run-windows` builds, deploys, and launches the app in one shot. Pass `--no-launch --no-deploy --no-packager` to only build.
 
-The app displays a simple view with a colored box that can be captured using ViewShot.
-This validates that the Windows module correctly:
+## What's covered
 
-- Integrates with React Native Windows
-- Captures view snapshots
-- Returns image URIs
+The home screen lists every test screen mirrored from `example/` (BasicTest, FullScreen, Transparency, ScrollView, Image, FS, Modal, Rendering, StyleFilters). Video / WebView / SVG screens are skipped because the underlying RN modules don't have Windows native support.
 
-## Known Issues
-
-- **CI Build Failure**: Windows build fails in GitHub Actions due to missing React Native Windows assemblies
-- **Dependencies**: React Native Windows 0.75.19 compatibility issues in CI environment
-- **Autolinking**: Windows autolinking may not work correctly in CI
-
-These issues are being tracked and will be resolved in future updates.
+`snapshotContentContainer` is documented as not supported on Windows — see the lib's `README.md`. The flag is silently ignored and a `console.warn` fires in `__DEV__`.

--- a/react-native.config.cjs
+++ b/react-native.config.cjs
@@ -11,9 +11,17 @@ module.exports = {
       windows: {
         sourceDir: "windows",
         solutionFile: "RNViewShot.sln",
-        project: {
-          projectFile: "RNViewShot\\RNViewShot.csproj",
-        },
+        projects: [
+          {
+            projectFile: "RNViewShot\\RNViewShot.csproj",
+            directDependency: true,
+            projectName: "RNViewShot",
+            projectLang: "cs",
+            projectGuid: "{64171807-A036-45AC-84F4-54EB8F6FB1E5}",
+            csNamespaces: ["RNViewShot"],
+            csPackageProviders: ["RNViewShot.ReactPackageProvider"],
+          },
+        ],
       },
     },
   },

--- a/windows/RNViewShot.Tests/HelpersTests.cs
+++ b/windows/RNViewShot.Tests/HelpersTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using RNViewShot;
+using Xunit;
+
+public class HelpersTests
+{
+    [Theory]
+    [InlineData("png", true)]
+    [InlineData("jpg", true)]
+    [InlineData("jpeg", true)]
+    [InlineData("webm", false)]
+    [InlineData("gif", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsSupportedFormat(string format, bool expected)
+    {
+        Assert.Equal(expected, Helpers.IsSupportedFormat(format));
+    }
+
+    [Theory]
+    [InlineData("jpg", "jpeg")]
+    [InlineData("jpeg", "jpeg")]
+    [InlineData("png", "png")]
+    public void MapMimeSubtype(string ext, string expected)
+    {
+        Assert.Equal(expected, Helpers.MapMimeSubtype(ext));
+    }
+
+    [Theory]
+    [InlineData("png", "data:image/png;base64,XYZ")]
+    [InlineData("jpg", "data:image/jpeg;base64,XYZ")]
+    [InlineData("jpeg", "data:image/jpeg;base64,XYZ")]
+    public void BuildDataUri_emitsCorrectMimeType(string ext, string expected)
+    {
+        Assert.Equal(expected, Helpers.BuildDataUri(ext, "XYZ"));
+    }
+
+    [Fact]
+    public void ResolveFileName_returnsExplicitPathWhenProvided()
+    {
+        Assert.Equal("custom.png", Helpers.ResolveFileName("custom.png", "png"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ResolveFileName_generatesGuidWhenPathMissing(string path)
+    {
+        var name = Helpers.ResolveFileName(path, "png");
+        Assert.EndsWith(".png", name);
+        var stem = Path.GetFileNameWithoutExtension(name);
+        Assert.True(Guid.TryParse(stem, out _), $"Expected GUID stem, got '{stem}'");
+    }
+}

--- a/windows/RNViewShot.Tests/HelpersTests.cs
+++ b/windows/RNViewShot.Tests/HelpersTests.cs
@@ -1,7 +1,8 @@
 using System;
 using System.IO;
-using RNViewShot;
 using Xunit;
+
+namespace RNViewShot.Tests;
 
 public class HelpersTests
 {

--- a/windows/RNViewShot.Tests/RNViewShot.Tests.csproj
+++ b/windows/RNViewShot.Tests/RNViewShot.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <NoWarn>NU1701</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\RNViewShot\Helpers.cs" Link="Helpers.cs" />
+  </ItemGroup>
+
+</Project>

--- a/windows/RNViewShot/Helpers.cs
+++ b/windows/RNViewShot/Helpers.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+
+namespace RNViewShot
+{
+    internal static class Helpers
+    {
+        public static bool IsSupportedFormat(string format)
+        {
+            return format == "png" || format == "jpg" || format == "jpeg";
+        }
+
+        public static string MapMimeSubtype(string extension)
+        {
+            return extension == "jpg" ? "jpeg" : extension;
+        }
+
+        public static string BuildDataUri(string extension, string base64)
+        {
+            return "data:image/" + MapMimeSubtype(extension) + ";base64," + base64;
+        }
+
+        public static string ResolveFileName(string path, string extension)
+        {
+            return !string.IsNullOrEmpty(path)
+                ? path
+                : Path.ChangeExtension(Guid.NewGuid().ToString(), extension);
+        }
+    }
+}

--- a/windows/RNViewShot/RNViewShot.csproj
+++ b/windows/RNViewShot/RNViewShot.csproj
@@ -130,6 +130,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Helpers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReactPackageProvider.cs" />
     <Compile Include="RNViewShotModule.cs" />

--- a/windows/RNViewShot/RNViewShotModule.cs
+++ b/windows/RNViewShot/RNViewShotModule.cs
@@ -68,7 +68,7 @@ namespace RNViewShot
             var result = options["result"].IsNull ? "tmpfile" : options["result"].AsString();
             var path = options["path"].IsNull ? null : options["path"].AsString();
 
-            if (format != "png" && format != "jpg" && format != "jpeg")
+            if (!Helpers.IsSupportedFormat(format))
             {
                 return "Unsupported image format: " + format + ". Try one of: png | jpg | jpeg";
             }

--- a/windows/RNViewShot/ViewShot.cs
+++ b/windows/RNViewShot/ViewShot.cs
@@ -43,8 +43,7 @@ namespace RNViewShot
                     var data = Convert.ToBase64String(imageBytes);
                     if (result == "data-uri")
                     {
-                        var mime = extension == "jpg" ? "jpeg" : extension;
-                        return "data:image/" + mime + ";base64," + data;
+                        return Helpers.BuildDataUri(extension, data);
                     }
                     return data;
                 }
@@ -112,7 +111,7 @@ namespace RNViewShot
         private static async Task<StorageFile> GetStorageFile(string path, string extension)
         {
             var storageFolder = ApplicationData.Current.LocalFolder;
-            var fileName = !string.IsNullOrEmpty(path) ? path : Path.ChangeExtension(Guid.NewGuid().ToString(), extension);
+            var fileName = Helpers.ResolveFileName(path, extension);
             return await storageFolder.CreateFileAsync(fileName, CreationCollisionOption.ReplaceExisting);
         }
     }


### PR DESCRIPTION
## Summary

The previous PR #640 left the `Build Windows` job in `ci.yml` as a stub: it echoed _"Windows build is temporarily disabled"_ and exited 0. The green check on PR #640 was misleading — nothing was actually compiled. This PR makes that job real and adds a fast unit-test job.

- **Real `Build Windows` job**. Runs the same flow that works locally: install deps, build the lib, autolink, then `react-native run-windows --no-launch --no-deploy --no-packager`. Verifies `ViewShotWindowsExample.exe` and `RNViewShot.winmd` are produced; uploads `buildlogs/` on failure. Removes ~150 lines of "verify-things-exist" debug output from the old stub.
- **New `Run Windows unit tests` job** (parallel to Build Windows so failures show up fast). Runs `dotnet test` against a new `windows/RNViewShot.Tests/` xUnit project (net8.0). The test project compiles `RNViewShot/Helpers.cs` in-place — no UWP host required, runs in a few seconds.
- **Extract pure logic to `windows/RNViewShot/Helpers.cs`**. `ViewShot.cs` / `RNViewShotModule.cs` now delegate `IsSupportedFormat`, `MapMimeSubtype`, `BuildDataUri`, `ResolveFileName`. Behavior unchanged; now testable.
- **First 16 unit tests** in `HelpersTests.cs` covering format validation, the Copilot-flagged `jpg → jpeg` MIME mapping, data-uri assembly, and filename generation (explicit path vs. GUID fallback).
- **Fix autolink dropping `RNViewShot` silently**. PR #640's path-discovery fix (replacing the literal `Microsoft.ReactNative.Uwp.CSharpLib.targets` import with a `$(ReactNativeWindowsTargetsFile)` variable) defeated RNW cli's heuristic project discovery, which uses an XPath `//msbuild:Import[contains(@Project,'…CSharpLib.targets')]`. Locally the autolinked file was already cached so the regression was invisible; on a clean checkout the lib was missing from `AutolinkedNativeModules.g.cs`. Switch `react-native.config.cjs` to declare the Windows project explicitly via a `projects: […]` array, bypassing the heuristic.

## Test plan

- [x] `dotnet test windows/RNViewShot.Tests/RNViewShot.Tests.csproj` — passes locally (16/16 in 301 ms).
- [x] `cd example-windows && npx react-native autolink-windows` — `AutolinkedNativeModules.g.cs` registers `RNViewShot.ReactPackageProvider`.
- [x] `cd example-windows && npx react-native run-windows --arch x64 --no-launch --no-deploy --no-packager` — succeeds, produces `bin/x64/Debug/Core/ViewShotWindowsExample.exe` + `bin/x64/Debug/RNViewShot.winmd`.
- [ ] CI runs and stays green (no more stub).
- [ ] iOS / Android / Web jobs still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)