### PR TITLE
fix(windows,ios): releaseCapture, error rejection, file:// URIs, podspec minimum

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -930,7 +930,7 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
         final int w = view.getWidth();
         final int h = view.getHeight();
 
-        return Math.min(w * h * ARGB_SIZE, 32);
+        return Math.max(w * h * ARGB_SIZE, 32);
     }
 
     /**

--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -930,7 +930,7 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
         final int w = view.getWidth();
         final int h = view.getHeight();
 
-        return Math.max(w * h * ARGB_SIZE, 32);
+        return Math.min(w * h * ARGB_SIZE, 32);
     }
 
     /**

--- a/react-native-view-shot.podspec
+++ b/react-native-view-shot.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "9.0"
+  s.platform     = :ios, "15.1"
 
   s.source       = { :git => "https://github.com/gre/react-native-view-shot.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,mm}"

--- a/windows/RNViewShot/RNViewShotModule.cs
+++ b/windows/RNViewShot/RNViewShotModule.cs
@@ -1,7 +1,9 @@
 using Microsoft.ReactNative;
 using Microsoft.ReactNative.Managed;
 using System;
+using System.IO;
 using System.Threading.Tasks;
+using Windows.Storage;
 using Windows.UI.Xaml;
 
 namespace RNViewShot
@@ -20,7 +22,31 @@ namespace RNViewShot
         [ReactMethod]
         public void releaseCapture(string uri)
         {
-            // TODO implement me
+            if (string.IsNullOrEmpty(uri)) return;
+            // Only delete files that live inside the app's local folder (where ViewShot.GetStorageFile writes).
+            var localFolder = ApplicationData.Current.LocalFolder.Path;
+            string fullPath;
+            try
+            {
+                fullPath = Path.GetFullPath(uri);
+            }
+            catch
+            {
+                return;
+            }
+            if (!fullPath.StartsWith(localFolder, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(fullPath, localFolder, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+            try
+            {
+                if (File.Exists(fullPath)) File.Delete(fullPath);
+            }
+            catch
+            {
+                // Best-effort cleanup; mirrors iOS/Android which silently ignore deletion errors.
+            }
         }
 
         [ReactMethod]
@@ -70,7 +96,7 @@ namespace RNViewShot
 
             if (!Helpers.IsSupportedFormat(format))
             {
-                return "Unsupported image format: " + format + ". Try one of: png | jpg | jpeg";
+                throw new ArgumentException("Unsupported image format: " + format + ". Try one of: png | jpg | jpeg");
             }
 
             var tcs = new TaskCompletionSource<string>();
@@ -84,7 +110,7 @@ namespace RNViewShot
                 }
                 catch (Exception ex)
                 {
-                    tcs.SetResult(ex.Message);
+                    tcs.SetException(ex);
                 }
             });
             return await tcs.Task;

--- a/windows/RNViewShot/RNViewShotModule.cs
+++ b/windows/RNViewShot/RNViewShotModule.cs
@@ -23,21 +23,19 @@ namespace RNViewShot
         public void releaseCapture(string uri)
         {
             if (string.IsNullOrEmpty(uri)) return;
-            // Only delete files that actually live inside the app's local
-            // folder (where ViewShot.GetStorageFile writes). Use
-            // Path.GetRelativePath rather than a string prefix check, which
-            // would otherwise let sibling paths like
-            // "...\LocalState2\file.png" pass a "...\LocalState" prefix.
-            var localFolder = ApplicationData.Current.LocalFolder.Path;
             string fullPath;
             try
             {
-                fullPath = Path.GetFullPath(uri);
+                // JS often passes file:// URIs (mirrors Android Uri.parse behaviour).
+                fullPath = Uri.TryCreate(uri, UriKind.Absolute, out var parsed) && parsed.IsFile
+                    ? parsed.LocalPath
+                    : Path.GetFullPath(uri);
             }
             catch
             {
                 return;
             }
+            var localFolder = ApplicationData.Current.LocalFolder.Path;
             string relative;
             try
             {
@@ -54,14 +52,8 @@ namespace RNViewShot
             {
                 return;
             }
-            try
-            {
-                if (File.Exists(fullPath)) File.Delete(fullPath);
-            }
-            catch
-            {
-                // Best-effort cleanup; mirrors iOS/Android which silently ignore deletion errors.
-            }
+            try { if (File.Exists(fullPath)) File.Delete(fullPath); }
+            catch { }
         }
 
         [ReactMethod]
@@ -114,18 +106,18 @@ namespace RNViewShot
                 throw new ArgumentException("Unsupported image format: " + format + ". Try one of: png | jpg | jpeg");
             }
 
-            var tcs = new TaskCompletionSource<string>();
+            var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             _context.Handle.UIDispatcher.Post(async () =>
             {
                 try
                 {
                     var target = resolveTarget();
                     var output = await ViewShot.Execute(target, format, quality, width, height, path, result);
-                    tcs.SetResult(output);
+                    tcs.TrySetResult(output);
                 }
                 catch (Exception ex)
                 {
-                    tcs.SetException(ex);
+                    tcs.TrySetException(ex);
                 }
             });
             return await tcs.Task;

--- a/windows/RNViewShot/RNViewShotModule.cs
+++ b/windows/RNViewShot/RNViewShotModule.cs
@@ -23,7 +23,11 @@ namespace RNViewShot
         public void releaseCapture(string uri)
         {
             if (string.IsNullOrEmpty(uri)) return;
-            // Only delete files that live inside the app's local folder (where ViewShot.GetStorageFile writes).
+            // Only delete files that actually live inside the app's local
+            // folder (where ViewShot.GetStorageFile writes). Use
+            // Path.GetRelativePath rather than a string prefix check, which
+            // would otherwise let sibling paths like
+            // "...\LocalState2\file.png" pass a "...\LocalState" prefix.
             var localFolder = ApplicationData.Current.LocalFolder.Path;
             string fullPath;
             try
@@ -34,8 +38,19 @@ namespace RNViewShot
             {
                 return;
             }
-            if (!fullPath.StartsWith(localFolder, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(fullPath, localFolder, StringComparison.OrdinalIgnoreCase))
+            string relative;
+            try
+            {
+                relative = Path.GetRelativePath(localFolder, fullPath);
+            }
+            catch
+            {
+                return;
+            }
+            if (string.IsNullOrEmpty(relative)
+                || relative == "."
+                || relative.StartsWith("..", StringComparison.Ordinal)
+                || Path.IsPathRooted(relative))
             {
                 return;
             }


### PR DESCRIPTION
## Summary

Tier 1 of a 3-PR cleanup pass — concrete bugs with low blast radius.

- **Windows `releaseCapture`** — was a `// TODO implement me` stub, leaking temp files written to `ApplicationData.Current.LocalFolder` indefinitely. Now uses `Path.GetRelativePath` (not a string prefix check) to confirm the URI lives inside the local folder before deleting. Also handles `file://` URIs (JS callers commonly pass them).
- **Windows error paths** — `tcs.SetResult(ex.Message)` was returning the exception string as if it were a successful capture URI, so JS promises never rejected on Windows. Switched to `TrySetException(ex)` (and `TrySetResult` on the success path) with `TaskCreationOptions.RunContinuationsAsynchronously` so continuations don't pile up on the dispatcher thread. Same shape for the unsupported-format early return (`throw new ArgumentException` instead of returning the message).
- **Podspec** — `s.platform = :ios, "9.0"` is misleading (the code already uses `UIGraphicsImageRenderer`, iOS 10+). Bumped to `15.1` to match the current React Native floor (the lib's existing peerDependency `react-native >=0.76.0` already requires this, so no new floor for valid consumers — but worth a CHANGELOG line on release).

> **Reverted in this branch (Copilot round 1):** the original draft also flipped `ViewShot.proposeSize` from `Math.min` to `Math.max`. Pre-existing JUnit tests pin the current `Math.min` behaviour, and the call site at `ViewShot.java:245-247` discards the configured stream — so the formula change has no functional effect and only breaks the tests. Reverted; left as-is.

## Test plan

- [x] `npm run type-check` — passes
- [x] `npm run lint:ci` — passes
- [x] `npm test` — 46 / 46
- [ ] Verify Windows example: `releaseCapture("file:///…/LocalState/foo.png")` deletes the file
- [ ] Verify Windows example: a thrown native error rejects the JS promise (instead of resolving with the error message string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
