### PR TITLE
fix: use TurboModuleRegistry as primary lookup to support RN 0.79+ bridgeless mode

### DIFF
--- a/src/specs/NativeRNViewShot.ts
+++ b/src/specs/NativeRNViewShot.ts
@@ -14,11 +14,9 @@ export interface Spec extends TurboModule {
   captureScreen: (options: Object) => Promise<string>;
 }
 
-const isTurboModuleEnabled =
-  (global as {__turboModuleProxy?: unknown}).__turboModuleProxy != null;
-
-const RNViewShotModule = isTurboModuleEnabled
-  ? TurboModuleRegistry.getEnforcing<Spec>("RNViewShot")
-  : NativeModules.RNViewShot;
+// In bridgeless mode (RN 0.79+) __turboModuleProxy is not set; use
+// TurboModuleRegistry as primary and fall back to legacy NativeModules.
+const RNViewShotModule =
+  TurboModuleRegistry.get<Spec>("RNViewShot") ?? NativeModules.RNViewShot;
 
 export default RNViewShotModule as Spec;


### PR DESCRIPTION
## Summary

- Removes the `global.__turboModuleProxy` heuristic
- Uses `TurboModuleRegistry.get()` as the primary resolver (the correct stable API for both old and new arch)
- Keeps `NativeModules.RNViewShot` as the legacy fallback

## Background

The previous code used `global.__turboModuleProxy != null` as a gate to decide between `TurboModuleRegistry.getEnforcing()` and `NativeModules.RNViewShot`. In RN 0.79+ bridgeless mode, `__turboModuleProxy` is null, so it fell through to `NativeModules.RNViewShot` — which is also absent in bridgeless (0 keys). This caused:

> react-native-view-shot: NativeModules.RNViewShot is undefined. Make sure the library is linked on the native side.

`TurboModuleRegistry.get()` is the correct API for module resolution in both old and new arch, including most bridgeless setups.

## Scope / Known Limitations

This PR fixes the JS-side module lookup heuristic. However, in fully bridgeless runtimes (RN 0.81 + Expo SDK 54, where `global.RN$UnifiedNativeModuleProxy === true`), runtime evidence shows `TurboModuleRegistry.get('RNViewShot')` itself returns `null`. This appears to be because the iOS native implementation depends on `self.bridge.uiManager addUIBlock:` — a bridge-only API — which prevents the TurboModule from initializing without a bridge. Full bridgeless support would require migrating the iOS view-lookup path away from `RCTUIManager`, which is tracked in #653 as a separate larger effort.

Related: #653

## Test plan

- [x] Code Quality (ESLint + TypeScript strict) passes
- [x] Web Playwright E2E passes
- [ ] Old arch (bridge mode) iOS: `captureRef` still works
- [ ] New arch (non-bridgeless) iOS: `captureRef` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)