### PR TITLE
ci(windows): pin build-windows to windows-2022 (VS 2022)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install --legacy-peer-deps  # Need --legacy-peer-deps for react-native-windows@0.74.47
+        run: npm install --legacy-peer-deps  # Need --legacy-peer-deps for react-native-windows@0.76.17
 
       - name: Check formatting (no prettier diff allowed)
         run: npm run format:check
@@ -75,7 +75,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Install dependencies
-        run: npm install --legacy-peer-deps  # Need --legacy-peer-deps for react-native-windows@0.74.47
+        run: npm install --legacy-peer-deps  # Need --legacy-peer-deps for react-native-windows@0.76.17
 
       - name: Build library
         run: npm run build
@@ -143,7 +143,7 @@ jobs:
             ${{ runner.os }}-pods-
 
       - name: Install dependencies
-        run: npm install --legacy-peer-deps  # Need --legacy-peer-deps for react-native-windows@0.74.47
+        run: npm install --legacy-peer-deps  # Need --legacy-peer-deps for react-native-windows@0.76.17
 
       - name: Build library
         run: npm run build
@@ -307,7 +307,10 @@ jobs:
 
   build-windows:
     name: Build Windows
-    runs-on: windows-latest
+    # Pinned to windows-2022 (VS 2022). GitHub migrated windows-latest to
+    # Visual Studio 2026 (18.x) in June 2026, which react-native-windows 0.76
+    # does not support — its CLI only accepts VS in range [17.11.0, 18.0).
+    runs-on: windows-2022
     needs: lint-and-type-check
 
     steps:


### PR DESCRIPTION
## Problem

The **Build Windows** CI job started failing on `master` (last green run 2026-05-27, failing since 2026-06-10) with:

```
Looking for VS installs with version range: [17.11.0,18.0)
✖ No public VS release found
✖ Could not find MSBuild with VCTools for Visual Studio 17.11.0 or later.
Command failed with error NoMSBuild
```

## Root cause

Nothing in the repo changed — GitHub migrated the `windows-latest` runner to **Visual Studio 2026 (internal version 18.x)** during **June 8–15, 2026** ([actions/runner-images#14017](https://github.com/actions/runner-images/issues/14017)). The first failure (June 10) falls right inside that window.

`react-native-windows@0.76.17` (used by `example-windows`) has a CLI that only accepts Visual Studio in the range **`[17.11.0, 18.0)`**. VS 2026 is `18.x`, outside that bound, so `react-native run-windows` can't find a usable MSBuild even though VS is installed. RNW has no released VS 2026 support yet ([microsoft/react-native-windows#15399](https://github.com/microsoft/react-native-windows/issues/15399)).

## Fix

Pin the `build-windows` job to **`windows-2022`**, which still ships VS 2022 17.x. GitHub explicitly directs VS 2022 users to this image and it is **not** scheduled for retirement ([GitHub Changelog](https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/)).

Also refreshed stale `# ...react-native-windows@0.74.47` comments — the example app actually uses `0.76.17`.

The proper long-term fix is upgrading react-native-windows once it supports VS 2026; that's a much larger change and not available today.

## Verification

CI will confirm on this PR. Locally: YAML parses, and pre-commit `format:check` / `lint:ci` / `type-check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)