### PR TITLE
fix: remove unused imports (RefObject, Int32)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,5 @@
 import React, {
   ReactNode,
-  RefObject,
   useRef,
   useCallback,
   useEffect,

--- a/src/specs/NativeRNViewShot.ts
+++ b/src/specs/NativeRNViewShot.ts
@@ -1,6 +1,6 @@
 import type {TurboModule} from "react-native";
 import {TurboModuleRegistry, NativeModules} from "react-native";
-import {Int32, WithDefault} from "react-native/Libraries/Types/CodegenTypes";
+import {WithDefault} from "react-native/Libraries/Types/CodegenTypes";
 
 // Options stay `Object` (codegen → ReadableMap / NSDictionary).
 // Narrowing here would force a coordinated change to both native module


### PR DESCRIPTION
## Summary

Two imports in the library source are declared but never used:

- `RefObject` in `src/index.tsx` — only `React.RefObject` (the qualified form) is referenced
- `Int32` in `src/specs/NativeRNViewShot.ts`

```
node_modules/react-native-view-shot/src/index.tsx(3,3): error TS6133: 'RefObject' is declared but its value is never read.
node_modules/react-native-view-shot/src/specs/NativeRNViewShot.ts(3,9): error TS6133: 'Int32' is declared but its value is never read.
```

`skipLibCheck` does not help here since these are `.tsx`/`.ts` source files, not `.d.ts`.