### PR TITLE
ci(ts): guard shipped source against unused-import errors (TS6133)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary

Follow-up to #663 (now merged). That PR removed two unused imports; this one adds a CI guard so the same class of error can't recur.

Enables in `tsconfig.json`:

```jsonc
"noUnusedLocals": true,
"noUnusedParameters": true,
```

## Why

Our package's `react-native` export condition resolves consumers straight to the raw `src/*.tsx` source. Strict consumer tsconfigs then type-check our source and surface `TS6133` ("declared but never read") on any unused import:

```
node_modules/react-native-view-shot/src/index.tsx(3,3): error TS6133: 'RefObject' is declared but its value is never read.
node_modules/react-native-view-shot/src/specs/NativeRNViewShot.ts(3,9): error TS6133: 'Int32' is declared but its value is never read.
```

`skipLibCheck` does **not** suppress this, because these are `.tsx`/`.ts` source files, not `.d.ts`.

Enabling `noUnusedLocals`/`noUnusedParameters` in our own `tsconfig.json` makes `npm run type-check` (already gating CI, and our husky pre-commit hook) catch the same error before publish — so it can never reach consumers again.

## Verification

- On the pre-#663 tree, this guard fails `npm run type-check` with exactly the two errors above.
- On current master (with #663 merged): type-check, lint, and format all pass green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)