### PR TITLE
ci(android): free disk space before Android APK build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # The Android assembleDebug build (RN new arch) exhausts the runner's
+      # ~14 GB of free disk. Reclaim space by removing large preinstalled
+      # toolchains we don't use, while keeping the Android SDK/NDK. Runs
+      # before Node/Java setup so their tool caches are untouched.
+      - name: Free up disk space
+        run: |
+          echo "Disk before cleanup:"; df -h /
+          sudo rm -rf /usr/share/dotnet \
+                      /opt/ghc /usr/local/.ghcup \
+                      /opt/hostedtoolcache/CodeQL \
+                      /usr/local/share/boost \
+                      /usr/local/share/powershell \
+                      /usr/local/lib/node_modules || true
+          sudo docker image prune --all --force || true
+          sudo swapoff -a || true
+          sudo rm -f /mnt/swapfile || true
+          sudo apt-get clean || true
+          echo "Disk after cleanup:"; df -h /
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Problem

The `build-android` job fails with **`No space left on device`** during `gradlew assembleDebug`:

> https://github.com/gre/react-native-view-shot/actions/runs/28114228682/job/83258056466

The RN new-architecture Android build is disk-heavy (codegen + Gradle caches + AAR/native artifacts), and the `ubuntu-latest` runner ships with only ~14 GB free. This is flaky/environmental — unrelated to any source change.

## Fix

Add a **Free up disk space** step right after checkout that reclaims ~20+ GB by removing large preinstalled toolchains the Android build doesn't use:

- .NET (`/usr/share/dotnet`)
- Haskell/GHC (`/opt/ghc`, `/usr/local/.ghcup`)
- CodeQL bundle (`/opt/hostedtoolcache/CodeQL`)
- boost, PowerShell, global npm `node_modules`
- docker images (`docker image prune`)
- swap file

### Safety

- Runs **before** the Node.js/Java setup steps, so their tool caches are created fresh afterward and are untouched.
- Does **not** remove the Android SDK/NDK (`/usr/local/lib/android`) — the build needs it.
- Every removal is guarded with `|| true`, so the step can't fail the job even if a path is missing on a future runner image.
- `df -h /` is printed before and after for visibility.

No third-party action is introduced — the step is plain, auditable shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)