### PR TITLE
fix(android): scale about the view pivot when capturing TextureView/SurfaceView content

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -896,12 +896,13 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
             final float dy = v.getTop() + ((v != child) ? v.getPaddingTop() : 0) + v.getTranslationY();
             c.translate(dx, dy);
             c.rotate(v.getRotation(), v.getPivotX(), v.getPivotY());
-            c.scale(v.getScaleX(), v.getScaleY());
+            // scale about the view's pivot, matching how android renders the view
+            c.scale(v.getScaleX(), v.getScaleY(), v.getPivotX(), v.getPivotY());
 
             // compute the matrix just for any future use
             transform.postTranslate(dx, dy);
             transform.postRotate(v.getRotation(), v.getPivotX(), v.getPivotY());
-            transform.postScale(v.getScaleX(), v.getScaleY());
+            transform.postScale(v.getScaleX(), v.getScaleY(), v.getPivotX(), v.getPivotY());
         }
 
         return transform;


### PR DESCRIPTION
Capturing a scaled TextureView/SurfaceView produces content at the correct size but anchored to the view's top-left corner instead of where it appears on screen. Cause: in `applyTransformations` the canvas scale is applied about the canvas origin, while Android renders view scale about the view's pivot (default: center) and the rotation call one line above already passes the pivot. Fix: pass the pivot to `Canvas.scale` (and the mirrored `Matrix.postScale`). Verified on a device against a scaled TextureView.

Minimal repro:

```jsx
<ViewShot ref={ref}>
  <View style={{ transform: [{ scale: 0.7 }] }}>
    <Video source={...} />  {/* any TextureView-backed view */}
  </View>
</ViewShot>
```

On screen the video appears scaled about its center; in the captured image it is scaled about the top-left corner.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_018o7Mf9BAF9qMStB698ab1L
