### PR TITLE
fix: normalize non-finite dimensions and invalid boolean options

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -137,20 +137,25 @@ function validateOptions(input?: CaptureOptions): {
   const errors: string[] = [];
   if (
     "width" in options &&
-    (typeof options.width !== "number" || options.width <= 0)
+    (typeof options.width !== "number" ||
+      !Number.isFinite(options.width) ||
+      options.width <= 0)
   ) {
     errors.push("option width should be a positive number");
     delete options.width;
   }
   if (
     "height" in options &&
-    (typeof options.height !== "number" || options.height <= 0)
+    (typeof options.height !== "number" ||
+      !Number.isFinite(options.height) ||
+      options.height <= 0)
   ) {
     errors.push("option height should be a positive number");
     delete options.height;
   }
   if (
     typeof options.quality !== "number" ||
+    !Number.isFinite(options.quality) ||
     options.quality < 0 ||
     options.quality > 1
   ) {
@@ -159,9 +164,12 @@ function validateOptions(input?: CaptureOptions): {
   }
   if (typeof options.snapshotContentContainer !== "boolean") {
     errors.push("option snapshotContentContainer should be a boolean");
+    options.snapshotContentContainer = defaultOptions.snapshotContentContainer;
   }
   if (typeof options.handleGLSurfaceViewOnAndroid !== "boolean") {
     errors.push("option handleGLSurfaceViewOnAndroid should be a boolean");
+    options.handleGLSurfaceViewOnAndroid =
+      defaultOptions.handleGLSurfaceViewOnAndroid;
   }
   if (acceptedFormats.indexOf(options.format || "") === -1) {
     const badFormat = options.format;


### PR DESCRIPTION
## Fixes

Reject NaN/infinite dimensions and quality before they reach native code, and actually restore defaults for invalid boolean options after reporting their warning.

## Compatibility / observable changes

No public signature changes. Malformed option values now follow the documented fallback behavior; valid positive dimensions, quality and booleans are preserved.

## Verification

Eight actual-source JS checks cover invalid and valid inputs.

This patch was applied independently to upstream commit `6acbec50a5e3cab7d668711d757c52cfdc791c76` and passed its targeted external actual-source diagnostics. Across the focused patches, 119 such checks pass. Java/Objective-C diagnostics use controlled bridge/platform doubles or owned filesystem fixtures; they are not substitutes for physical-device rendering tests.

Combined branch checks:

- Existing JS suite: 4 suites, 46 tests pass.
- TypeScript, ESLint (zero warnings), full Prettier check and library build pass.
- Existing Android unit suite: 62 tests pass; Android Debug example build passes.
- Existing Windows managed helper suite: 16 tests pass on .NET 8.
- Unsigned iOS Simulator example build passes. Native tests: 13/14 pass; the one intentional old-behavior assertion conflict is described below.
- Android and iOS production Metro bundles pass. Web production build passes with three bundle-size warnings.
- React 18.3.1: all 21 applicable JS diagnostic controls pass; React 19 includes callback-ref cleanup coverage.

The separate iOS cleanup patch intentionally makes the existing test named `testReleaseCapture_currentlyDeletesPrefixOnlyImposterDirectories_KNOWN_LOOSE_GUARD` fail because it asserts the unsafe old behavior. That patch is kept in a separate draft PR. No checked-in test/spec or snapshot files were added, modified, regenerated or disabled.

Windows/Expo native builds, physical-device video/PixelCopy output, and full Detox suites were not run. The full unchanged Playwright suite was run against both baseline and patched builds: both have 9 passes and the same 3 failures. Two Linux-reference screenshot mismatches have byte-identical baseline/patched actual images on macOS. The CORS fixture hard-codes port 3000, occupied by an unrelated local backend; the isolated example uses another port. No snapshots or assertions were changed. React Doctor also reports existing example suggestions and a React-18 ref-cleanup warning; the latter was checked against actual React 18 legacy-ref and React 19 cleanup behavior. No rules were suppressed.

## Scope

- `src/index.tsx`

Unrelated audit changes are submitted separately.
