### PR TITLE
fix: stabilize capture scheduling and React 19 ref lifecycle

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -321,19 +321,14 @@ const ViewShotComponent = forwardRef<ViewShotRef, ViewShotProperties>(
     } = props;
 
     const rootRef = useRef<View | null>(null);
-    const rafRef = useRef<number | null>(null);
     const lastCapturedURIRef = useRef<string | null>(null);
-    const resolveFirstLayoutRef = useRef<((layout: unknown) => void) | null>(
-      null,
-    );
-
-    const firstLayoutPromise = useMemo(
-      () =>
-        new Promise<unknown>(resolve => {
-          resolveFirstLayoutRef.current = resolve;
-        }),
-      [],
-    );
+    const firstLayout = useMemo(() => {
+      let resolve!: (layout: unknown) => void;
+      const promise = new Promise<unknown>(r => {
+        resolve = r;
+      });
+      return {promise, resolve: resolve as ((layout: unknown) => void) | null};
+    }, []);
 
     // Keep latest props in refs so stable callbacks always see fresh values
     const onCaptureRef = useRef(onCapture);
@@ -345,7 +340,7 @@ const ViewShotComponent = forwardRef<ViewShotRef, ViewShotProperties>(
 
     const capture = useCallback(
       (): Promise<string> =>
-        firstLayoutPromise
+        firstLayout.promise
           .then(() => {
             if (!rootRef.current) return neverEndingPromise as Promise<never>;
             return captureRef(rootRef.current, optionsRef.current);
@@ -353,7 +348,10 @@ const ViewShotComponent = forwardRef<ViewShotRef, ViewShotProperties>(
           .then(
             uri => {
               if (!rootRef.current) return uri;
-              if (lastCapturedURIRef.current) {
+              if (
+                lastCapturedURIRef.current &&
+                lastCapturedURIRef.current !== uri
+              ) {
                 setTimeout(releaseCapture, 500, lastCapturedURIRef.current);
               }
               lastCapturedURIRef.current = uri;
@@ -366,15 +364,22 @@ const ViewShotComponent = forwardRef<ViewShotRef, ViewShotProperties>(
               throw e;
             },
           ) as Promise<string>,
-      [firstLayoutPromise],
+      [firstLayout],
     );
 
     const setRootRef = useCallback(
-      (node: View | null): void => {
+      (node: View | null): void | (() => void) => {
         rootRef.current = node;
         if (node) (node as ViewShotRef).capture = capture;
         if (typeof ref === "function") {
-          ref(node as ViewShotRef | null);
+          // ForwardedRef still types callback returns as void, even in React 19.
+          const cleanup: unknown = ref(node as ViewShotRef | null);
+          if (typeof cleanup === "function") {
+            return () => {
+              rootRef.current = null;
+              cleanup();
+            };
+          }
         } else if (ref) {
           ref.current = node as ViewShotRef | null;
         }
@@ -382,26 +387,13 @@ const ViewShotComponent = forwardRef<ViewShotRef, ViewShotProperties>(
       [capture, ref],
     );
 
-    const syncCaptureLoop = useCallback(
-      (mode: ViewShotProperties["captureMode"] | null): void => {
-        cancelAnimationFrame(rafRef.current as number);
-        if (mode === "continuous") {
-          let previousCaptureURI: string | null = "-";
-          const loop = (): void => {
-            rafRef.current = requestAnimationFrame(loop);
-            if (previousCaptureURI === lastCapturedURIRef.current) return;
-            previousCaptureURI = lastCapturedURIRef.current;
-            capture();
-          };
-          rafRef.current = requestAnimationFrame(loop);
-        }
-      },
-      [capture],
-    );
-
+    const didMountCapture = useRef(false);
     useEffect(() => {
       if (__DEV__) checkCompatibleProps(props);
-      if (captureMode === "mount") capture();
+      if (captureMode === "mount" && !didMountCapture.current) {
+        didMountCapture.current = true;
+        void capture().catch(() => {});
+      }
       // Run once: re-firing on prop changes would double-trigger `mount`
       // capture; the `[captureMode]` effect below handles loop sync, and the
       // no-deps effect below handles `update` mode.
@@ -409,28 +401,39 @@ const ViewShotComponent = forwardRef<ViewShotRef, ViewShotProperties>(
     }, []);
 
     useEffect(() => {
-      syncCaptureLoop(captureMode);
-      return () => syncCaptureLoop(null);
-    }, [captureMode, syncCaptureLoop]);
+      if (captureMode !== "continuous") return;
+      let active = true;
+      let frame: number;
+      const schedule = (): void => {
+        if (active) frame = requestAnimationFrame(loop);
+      };
+      const loop = (): void => {
+        void capture().then(schedule, schedule);
+      };
+      schedule();
+      return () => {
+        active = false;
+        cancelAnimationFrame(frame);
+      };
+    }, [captureMode, capture]);
 
-    const isFirstRender = useRef(true);
+    const previousProps = useRef(props);
     useEffect(() => {
-      if (isFirstRender.current) {
-        isFirstRender.current = false;
-        return;
+      if (previousProps.current !== props && captureMode === "update") {
+        void capture().catch(() => {});
       }
-      if (captureMode === "update") capture();
+      previousProps.current = props;
     });
 
     const onLayoutHandler = useCallback(
       (e: LayoutChangeEvent): void => {
-        if (resolveFirstLayoutRef.current) {
-          resolveFirstLayoutRef.current(e.nativeEvent.layout);
-          resolveFirstLayoutRef.current = null;
+        if (firstLayout.resolve) {
+          firstLayout.resolve(e.nativeEvent.layout);
+          firstLayout.resolve = null;
         }
         if (onLayout) onLayout(e);
       },
-      [onLayout],
+      [firstLayout, onLayout],
     );
 
     return (


### PR DESCRIPTION
## Fixes

Keep the first-layout promise paired with its resolver during StrictMode replay, avoid duplicate mount captures, distinguish actual updates from effect replay, schedule continuous frames only after capture settles, handle automatic rejections, preserve React 19 callback-ref cleanup, and avoid releasing a repeated current URI.

## Compatibility / observable changes

Imperative capture still rejects on native failure. Automatic failures invoke onCaptureFailure without an unhandled rejection. Continuous capture retries on a later frame after failure and does not spin animation frames while a capture is pending. Legacy callback refs still receive null. No new API or dependency requirements.

## Verification

Fourteen actual React-rendered checks include StrictMode, callback cleanup, repeated URI, deferred native work, mode changes, unmount and failure controls.

This patch was applied independently to upstream commit `6acbec50a5e3cab7d668711d757c52cfdc791c76` and passed its targeted external actual-source diagnostics. Across the focused patches, 119 such checks pass. Java/Objective-C diagnostics use controlled bridge/platform doubles or owned filesystem fixtures; they are not substitutes for physical-device rendering tests.

Combined branch checks:

- Existing JS suite: 4 suites, 46 tests pass.
- TypeScript, ESLint (zero warnings), full Prettier check and library build pass.
- Existing Android unit suite: 62 tests pass; Android Debug example build passes.
- Existing Windows managed helper suite: 16 tests pass on .NET 8.
- Unsigned iOS Simulator example build passes. Native tests: 13/14 pass; the one intentional old-behavior assertion conflict is described below.
- Android and iOS production Metro bundles pass. Web production build passes with three bundle-size warnings.
- React 18.3.1: all 21 applicable JS diagnostic controls pass; React 19 includes callback-ref cleanup coverage.

The separate iOS cleanup patch intentionally makes the existing test named `testReleaseCapture_currentlyDeletesPrefixOnlyImposterDirectories_KNOWN_LOOSE_GUARD` fail because it asserts the unsafe old behavior. That patch is kept in a separate draft PR. No checked-in test/spec or snapshot files were added, modified, regenerated or disabled.

Windows/Expo native builds, physical-device video/PixelCopy output, and full Detox suites were not run. The full unchanged Playwright suite was run against both baseline and patched builds: both have 9 passes and the same 3 failures. Two Linux-reference screenshot mismatches have byte-identical baseline/patched actual images on macOS. The CORS fixture hard-codes port 3000, occupied by an unrelated local backend; the isolated example uses another port. No snapshots or assertions were changed. React Doctor also reports existing example suggestions and a React-18 ref-cleanup warning; the latter was checked against actual React 18 legacy-ref and React 19 cleanup behavior. No rules were suppressed.

## Scope

- `src/index.tsx`

Unrelated audit changes are submitted separately.
