### PR TITLE
fix(android): isolate capture buffers and encode the actual bitmap size

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -139,7 +139,12 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
     /**
      * Image output buffer used as a source for base64 encoding
      */
-    private static byte[] outputBuffer = new byte[PREALLOCATE_SIZE];
+    private static final ThreadLocal<byte[]> outputBuffer = new ThreadLocal<byte[]>() {
+        @Override
+        protected byte[] initialValue() {
+            return new byte[PREALLOCATE_SIZE];
+        }
+    };
     //endregion
 
     //region Class members
@@ -242,10 +247,6 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
             @Override
             public void run() {
                 try {
-                    final ReusableByteArrayOutputStream stream = new ReusableByteArrayOutputStream(outputBuffer);
-                    stream.setSize(proposeSize(view));
-                    outputBuffer = stream.innerBuffer();
-
                     if (Results.TEMP_FILE.equals(result) && Formats.RAW == format) {
                         saveToRawFileOnDevice(view);
                     } else if (Results.TEMP_FILE.equals(result) && Formats.RAW != format) {
@@ -275,33 +276,34 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
     private void saveToRawFileOnDevice(@NonNull final View view) throws IOException {
         final String uri = Uri.fromFile(output).toString();
 
-        final FileOutputStream fos = new FileOutputStream(output);
-        final ReusableByteArrayOutputStream os = new ReusableByteArrayOutputStream(outputBuffer);
-        final Point size = captureView(view, os);
+        try (final FileOutputStream fos = new FileOutputStream(output)) {
+            final ReusableByteArrayOutputStream os = new ReusableByteArrayOutputStream(outputBuffer.get());
+            final Point size = captureView(view, os);
 
-        // in case of buffer grow that will be a new array with bigger size
-        outputBuffer = os.innerBuffer();
-        final int length = os.size();
-        final String resolution = String.format(Locale.US, "%d:%d|", size.x, size.y);
+            // Keep the grown buffer for the next capture on this worker.
+            outputBuffer.set(os.innerBuffer());
+            final int length = os.size();
+            final String resolution = String.format(Locale.US, "%d:%d|", size.x, size.y);
 
-        fos.write(resolution.getBytes(Charset.forName("US-ASCII")));
-        fos.write(outputBuffer, 0, length);
-        fos.close();
+            fos.write(resolution.getBytes(Charset.forName("US-ASCII")));
+            fos.write(os.innerBuffer(), 0, length);
+        }
 
         promise.resolve(uri);
     }
 
     private void saveToDataUriString(@NonNull final View view) throws IOException {
-        final ReusableByteArrayOutputStream os = new ReusableByteArrayOutputStream(outputBuffer);
+        final ReusableByteArrayOutputStream os = new ReusableByteArrayOutputStream(outputBuffer.get());
         captureView(view, os);
 
-        outputBuffer = os.innerBuffer();
+        outputBuffer.set(os.innerBuffer());
         final int length = os.size();
 
-        final String data = Base64.encodeToString(outputBuffer, 0, length, Base64.NO_WRAP);
+        final String data = Base64.encodeToString(os.innerBuffer(), 0, length, Base64.NO_WRAP);
 
         // correct the extension if JPG
-        final String imageFormat = "jpg".equals(extension) ? "jpeg" : extension;
+        final String imageFormat = "jpg".equals(extension) ? "jpeg"
+                : "webm".equals(extension) ? "webp" : extension;
 
         promise.resolve("data:image/" + imageFormat + ";base64," + data);
     }
@@ -310,11 +312,11 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
         final boolean isRaw = Formats.RAW == this.format;
         final boolean isZippedBase64 = Results.ZIP_BASE_64.equals(this.result);
 
-        final ReusableByteArrayOutputStream os = new ReusableByteArrayOutputStream(outputBuffer);
+        final ReusableByteArrayOutputStream os = new ReusableByteArrayOutputStream(outputBuffer.get());
         final Point size = captureView(view, os);
 
         // in case of buffer grow that will be a new array with bigger size
-        outputBuffer = os.innerBuffer();
+        outputBuffer.set(os.innerBuffer());
         final int length = os.size();
         final String resolution = String.format(Locale.US, "%d:%d|", size.x, size.y);
         final String header = (isRaw ? resolution : "");
@@ -322,19 +324,23 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
 
         if (isZippedBase64) {
             final Deflater deflater = new Deflater();
-            deflater.setInput(outputBuffer, 0, length);
-            deflater.finish();
+            try {
+                deflater.setInput(os.innerBuffer(), 0, length);
+                deflater.finish();
 
-            final ReusableByteArrayOutputStream zipped = new ReusableByteArrayOutputStream(new byte[32]);
-            byte[] buffer = new byte[1024];
-            while (!deflater.finished()) {
-                int count = deflater.deflate(buffer); // returns the generated code... index
-                zipped.write(buffer, 0, count);
+                final ReusableByteArrayOutputStream zipped = new ReusableByteArrayOutputStream(new byte[32]);
+                byte[] buffer = new byte[1024];
+                while (!deflater.finished()) {
+                    int count = deflater.deflate(buffer);
+                    zipped.write(buffer, 0, count);
+                }
+
+                data = header + Base64.encodeToString(zipped.innerBuffer(), 0, zipped.size(), Base64.NO_WRAP);
+            } finally {
+                deflater.end();
             }
-
-            data = header + Base64.encodeToString(zipped.innerBuffer(), 0, zipped.size(), Base64.NO_WRAP);
         } else {
-            data = header + Base64.encodeToString(outputBuffer, 0, length, Base64.NO_WRAP);
+            data = header + Base64.encodeToString(os.innerBuffer(), 0, length, Base64.NO_WRAP);
         }
 
         promise.resolve(data);
@@ -806,18 +812,22 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
                 final Bitmap toRecycle = originalToRecycle.getAndSet(null);
                 if (toRecycle != null) recycleBitmap(toRecycle);
                 bitmap = scaledBitmap;
+                resolution.x = bitmap.getWidth();
+                resolution.y = bitmap.getHeight();
             }
 
             // special case, just save RAW ARGB array without any compression
             if (Formats.RAW == this.format && os instanceof ReusableByteArrayOutputStream) {
-                final int total = w * h * ARGB_SIZE;
+                final int total = bitmap.getByteCount();
                 final ReusableByteArrayOutputStream rbaos = cast(os);
                 bitmap.copyPixelsToBuffer(rbaos.asBuffer(total));
                 rbaos.setSize(total);
             } else {
                 final Bitmap.CompressFormat cf = Formats.mapping[this.format];
 
-                bitmap.compress(cf, (int) (100.0 * quality), os);
+                if (!bitmap.compress(cf, (int) (100.0 * quality), os)) {
+                    throw new RuntimeException("Failed to encode snapshot bitmap");
+                }
             }
 
             return resolution; // return image width and height


### PR DESCRIPTION
## Fixes

Use per-worker reusable output buffers so concurrent captures cannot overwrite each other; close raw-file streams and Deflaters on failure; write resized RAW dimensions/bytes; reject failed bitmap compression; report the WebP MIME type for the legacy webm alias. Remove the unused preallocation stream.

## Compatibility / observable changes

RAW resize results now carry dimensions matching their pixel payload. The deprecated webm alias still encodes WebP, now with the correct data URI MIME. Failed encoding rejects instead of returning an empty success. Existing PNG/JPEG/WebP output formats and native dependency versions are unchanged.

## Verification

Compiled actual Java methods reproduce cross-worker byte corruption, resource leaks, resize failures and incorrect MIME. Real zlib round-trip control passes. Native bitmap/bridge behavior is modeled with doubles; existing Android unit suite and example build also pass.

This patch was applied independently to upstream commit `6acbec50a5e3cab7d668711d757c52cfdc791c76` and passed its targeted external actual-source diagnostics. Across the focused patches, 119 such checks pass. Java/Objective-C diagnostics use controlled bridge/platform doubles or owned filesystem fixtures; they are not substitutes for physical-device rendering tests.

Combined branch checks:

- Existing JS suite: 4 suites, 46 tests pass.
- TypeScript, ESLint (zero warnings), full Prettier check and library build pass.
- Existing Android unit suite: 62 tests pass; Android Debug example build passes.
- Existing Windows managed helper suite: 16 tests pass on .NET 8.
- Unsigned iOS Simulator example build passes. Native tests: 13/14 pass; the one intentional old-behavior assertion conflict is described below.
- Android and iOS production Metro bundles pass. Web production build passes with three bundle-size warnings.
- React 18.3.1: all 21 applicable JS diagnostic controls pass; React 19 includes callback-ref cleanup coverage.

The separate iOS cleanup patch intentionally makes the existing test named `testReleaseCapture_currentlyDeletesPrefixOnlyImposterDirectories_KNOWN_LOOSE_GUARD` fail because it asserts the unsafe old behavior. That patch is kept in a separate draft PR. No checked-in test/spec or snapshot files were added, modified, regenerated or disabled.

Windows/Expo native builds, physical-device video/PixelCopy output, and full Detox suites were not run. The full unchanged Playwright suite was run against both baseline and patched builds: both have 9 passes and the same 3 failures. Two Linux-reference screenshot mismatches have byte-identical baseline/patched actual images on macOS. The CORS fixture hard-codes port 3000, occupied by an unrelated local backend; the isolated example uses another port. No snapshots or assertions were changed. React Doctor also reports existing example suggestions and a React-18 ref-cleanup warning; the latter was checked against actual React 18 legacy-ref and React 19 cleanup behavior. No rules were suppressed.

## Scope

- `android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java`

Unrelated audit changes are submitted separately.
