### PR TITLE
perf(android): avoid redundant traversal and transform allocations

### DIFF
--- a/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
-import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Point;
 import android.net.Uri;
@@ -41,7 +40,6 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -511,24 +509,20 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
 
     @NonNull
     static List<View> getAllChildren(@NonNull final View v) {
-        if (!(v instanceof ViewGroup)) {
-            final ArrayList<View> viewArrayList = new ArrayList<>();
-            viewArrayList.add(v);
-
-            return viewArrayList;
-        }
-
         final ArrayList<View> result = new ArrayList<>();
-
-        ViewGroup viewGroup = (ViewGroup) v;
-        for (int i = 0; i < viewGroup.getChildCount(); i++) {
-            View child = viewGroup.getChildAt(i);
-
-            //Do not add any parents, just add child elements
-            result.addAll(getAllChildren(child));
-        }
-
+        collectChildren(v, result);
         return result;
+    }
+
+    private static void collectChildren(@NonNull final View v, @NonNull final List<View> result) {
+        if (!(v instanceof ViewGroup)) {
+            result.add(v);
+        } else {
+            final ViewGroup group = (ViewGroup) v;
+            for (int i = 0; i < group.getChildCount(); i++) {
+                collectChildren(group.getChildAt(i), result);
+            }
+        }
     }
 
     /**
@@ -860,7 +854,7 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
      */
     @NonNull
     static List<View> walkAncestors(@NonNull final View child, @NonNull final View root) {
-        final LinkedList<View> ms = new LinkedList<>();
+        final List<View> ms = new ArrayList<>();
         if (child == root) {
             return ms;
         }
@@ -876,21 +870,11 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
     /**
      * Concat all the transformation matrix's from parent to child.
      */
-    @NonNull
-    @SuppressWarnings("UnusedReturnValue")
-    private Matrix applyTransformations(final Canvas c, @NonNull final View root, @NonNull final View child) {
-        final Matrix transform = new Matrix();
-        final LinkedList<View> ms = new LinkedList<>(walkAncestors(child, root));
-        if (ms.isEmpty()) {
-            return transform;
-        }
-
+    private void applyTransformations(final Canvas c, @NonNull final View root, @NonNull final View child) {
+        final List<View> ms = walkAncestors(child, root);
         // apply transformations from parent --> child order
-        Collections.reverse(ms);
-
-        for (final View v : ms) {
-            c.save();
-
+        for (int i = ms.size() - 1; i >= 0; i--) {
+            final View v = ms.get(i);
             // apply each view transformations, so each child will be affected by them
             final float dx = v.getLeft() + ((v != child) ? v.getPaddingLeft() : 0) + v.getTranslationX();
             final float dy = v.getTop() + ((v != child) ? v.getPaddingTop() : 0) + v.getTranslationY();
@@ -898,13 +882,7 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
             c.rotate(v.getRotation(), v.getPivotX(), v.getPivotY());
             c.scale(v.getScaleX(), v.getScaleY());
 
-            // compute the matrix just for any future use
-            transform.postTranslate(dx, dy);
-            transform.postRotate(v.getRotation(), v.getPivotX(), v.getPivotY());
-            transform.postScale(v.getScaleX(), v.getScaleY());
         }
-
-        return transform;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Fixes

Collect leaves into one output list, retain one ancestor array list, iterate it in reverse order without copying, and remove unused matrix construction and per-ancestor canvas saves. The caller already saves/restores the complete overlay transform.

## Compatibility / observable changes

Leaf ordering and parent-to-child translate/rotate/scale operations are unchanged, including root and detached-view cases. This does not implement the separate clipping/pivot corrections in open PRs #656 and #676.

## Verification

Compiled actual Java methods verify unchanged leaf and transform ordering with one list allocation and no unused matrix or canvas saves. Existing ancestor and child collection tests pass.

This patch was applied independently to upstream commit `6acbec50a5e3cab7d668711d757c52cfdc791c76` and passed its targeted external actual-source diagnostics. Across the focused patches, 119 such checks pass. Java/Objective-C diagnostics use controlled bridge/platform doubles or owned filesystem fixtures; they are not substitutes for physical-device rendering tests.

Combined branch checks:

- Existing JS suite: 4 suites, 46 tests pass.
- TypeScript, ESLint (zero warnings), full Prettier check and library build pass.
- Existing Android unit suite: 62 tests pass; Android Debug example build passes.
- Existing Windows managed helper suite: 16 tests pass on .NET 8.
- Unsigned iOS Simulator example build passes. Native tests: 13/14 pass; the one intentional old-behavior assertion conflict is described below.
- Android and iOS production Metro bundles pass. Web production build passes with three bundle-size warnings.
- React 18.3.1: all 21 applicable JS diagnostic controls pass; React 19 includes callback-ref cleanup coverage.

The separate iOS cleanup patch intentionally makes the existing test named `testReleaseCapture_currentlyDeletesPrefixOnlyImposterDirectories_KNOWN_LOOSE_GUARD` fail because it asserts the unsafe old behavior. That patch is kept in a separate draft PR. No checked-in test/spec or snapshot files were added, modified, regenerated or disabled.

Windows/Expo native builds, physical-device video/PixelCopy output, and full Detox suites were not run. The full unchanged Playwright suite was run against both baseline and patched builds: both have 9 passes and the same 3 failures. Two Linux-reference screenshot mismatches have byte-identical baseline/patched actual images on macOS. The CORS fixture hard-codes port 3000, occupied by an unrelated local backend; the isolated example uses another port. No snapshots or assertions were changed. React Doctor also reports existing example suggestions and a React-18 ref-cleanup warning; the latter was checked against actual React 18 legacy-ref and React 19 cleanup behavior. No rules were suppressed.

## Scope

- `android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java`

Unrelated audit changes are submitted separately.
