### PR TITLE
fix(ios): constrain releaseCapture to direct temporary files

### DIFF
--- a/example/ios/ViewShotExampleTests/RNViewShotReleaseCaptureTests.mm
+++ b/example/ios/ViewShotExampleTests/RNViewShotReleaseCaptureTests.mm
@@ -117,18 +117,11 @@
   XCTAssertFalse([self.fm fileExistsAtPath:missing]);
 }
 
-- (void)testReleaseCapture_currentlyDeletesPrefixOnlyImposterDirectories_KNOWN_LOOSE_GUARD
+- (void)testReleaseCapture_preservesFilesInPrefixOnlyImposterDirectories
 {
-  // KNOWN LOOSE GUARD — this test documents EXISTING (buggy) behaviour, not the
-  // desired one.
-  //
-  // A path that starts with `<tmp>/ReactNative` as a string prefix but is NOT
-  // inside the directory (e.g. `<tmp>/ReactNativeImposter/foo`) is currently
-  // deleted, because the implementation uses [hasPrefix:] without a path
-  // component boundary check. This is a latent bug that should be tightened in
-  // a future PR (e.g. require the prefix to end with "/" or compare path
-  // components). When that fix lands, flip this test to assert the imposter
-  // file is preserved and rename accordingly.
+  // A path that starts with `<tmp>/ReactNative` as a string prefix but is not
+  // inside the directory (e.g. `<tmp>/ReactNativeImposter/foo`) must be left
+  // alone.
   NSString *imposterDir = [NSTemporaryDirectory()
                            stringByAppendingPathComponent:@"ReactNativeImposter"];
   NSString *imposterPath = [imposterDir stringByAppendingPathComponent:@"file.png"];
@@ -137,14 +130,9 @@
 
   [self.module releaseCapture:imposterPath];
 
-  // With the current `hasPrefix:` check, the file IS deleted because
-  // "<tmp>/ReactNativeImposter/file.png" starts with "<tmp>/ReactNative".
-  // Asserting observed behaviour so a future hardening of the guard is caught
-  // here as a failure (and prompts a rename of this test).
-  XCTAssertFalse([self.fm fileExistsAtPath:imposterPath],
-                 @"current impl deletes prefix-matching paths; once the guard "
-                 @"is tightened to require a path-component boundary, flip this "
-                 @"assertion and rename the test");
+  XCTAssertTrue([self.fm fileExistsAtPath:imposterPath],
+                @"releaseCapture must not delete files outside %@",
+                self.reactNativeTmpDir);
 
   // Cleanup
   [self.fm removeItemAtPath:imposterDir error:NULL];

--- a/ios/RNViewShot.mm
+++ b/ios/RNViewShot.mm
@@ -9,6 +9,9 @@
 #import <React/RCTUIManagerUtils.h>
 #endif
 #import <React/RCTBridge.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <rnviewshot/rnviewshot.h>
@@ -35,13 +38,22 @@ RCT_EXPORT_METHOD(captureScreen: (NSDictionary *)options
 RCT_EXPORT_METHOD(releaseCapture:(nonnull NSString *)uri)
 {
   NSString *directory = [NSTemporaryDirectory() stringByAppendingPathComponent:@"ReactNative"];
-  // Ensure it's a valid file in the tmp directory
-  if ([uri hasPrefix:directory] && ![uri isEqualToString:directory]) {
-    NSFileManager *fileManager = [NSFileManager new];
-    if ([fileManager fileExistsAtPath:uri]) {
-      [fileManager removeItemAtPath:uri error:NULL];
-    }
+  NSString *prefix = [directory stringByAppendingString:@"/"];
+  if (![uri hasPrefix:prefix]) return;
+  NSString *name = [uri substringFromIndex:prefix.length];
+  if (name.length == 0 || [name isEqualToString:@"."] || [name isEqualToString:@".."] ||
+      [name containsString:@"/"] || [name containsString:@"\0"]) return;
+
+  // Captures are direct temporary-file children. Use file-only, descriptor-relative
+  // deletion so a changed leaf cannot redirect cleanup or become a recursive delete.
+  int directoryFD = open(directory.fileSystemRepresentation, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (directoryFD < 0) return;
+  struct stat info;
+  const char *fileName = name.fileSystemRepresentation;
+  if (fileName && fstatat(directoryFD, fileName, &info, AT_SYMLINK_NOFOLLOW) == 0 && S_ISREG(info.st_mode)) {
+    unlinkat(directoryFD, fileName, 0);
   }
+  close(directoryFD);
 }
 
 RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target


### PR DESCRIPTION
## Summary

Constrain `releaseCapture` to regular files that are direct children of React Native's temporary directory.

The implementation replaces raw string-prefix recursive removal with exact-root/direct-child validation and descriptor-relative, nonrecursive deletion. It rejects traversal, prefix siblings, directories, NULs, and symbolic-link escapes while preserving raw paths returned by `RCTTempFilePath`.

The native regression test now verifies that a file in a prefix-only sibling such as `ReactNativeImposter` is preserved.

## Compatibility

Normal native-generated capture paths continue to release correctly. Arbitrary paths that merely share the temporary-root prefix, nested paths, directories, and symbolic links are no longer removed. No dependency or SDK version changes.

## Verification

- Focused iOS Simulator XCTest target: 5 tests passed, 0 failures
- The targeted test covers normal capture deletion, missing files, outside paths, the root directory itself, and prefix-only sibling paths
- `git diff --check`

Type: fix