### PR TITLE
fix(example): ignore stale captures and release temporary previews

### DIFF
--- a/example-windows/src/components/shared/hooks/useViewShotCapture.ts
+++ b/example-windows/src/components/shared/hooks/useViewShotCapture.ts
@@ -1,31 +1,34 @@
-import {useState, useCallback, useRef} from "react";
-import {captureRef} from "react-native-view-shot";
+import {useState, useCallback, useRef, useEffect} from "react";
+import {
+  captureRef,
+  releaseCapture,
+  type CaptureOptions,
+  type ViewShotRef,
+} from "react-native-view-shot";
 
-export interface CaptureOptions {
-  format?: "png" | "jpg" | "webm";
-  quality?: number;
-  result?: "tmpfile" | "base64" | "zip-base64" | "data-uri";
-  handleGLSurfaceViewOnAndroid?: boolean;
-}
+export type {CaptureOptions} from "react-native-view-shot";
 
 export const useViewShotCapture = (successMessage?: string) => {
-  const [capturedUri, setCapturedUri] = useState<string | null>(null);
+  const [capture, setCapture] = useState<{
+    uri: string;
+    temporary: boolean;
+  } | null>(null);
   const [isCapturing, setIsCapturing] = useState(false);
-  const viewShotRef = useRef<any>(null);
+  const viewShotRef = useRef<ViewShotRef | null>(null);
+  const requestId = useRef(0);
 
-  const onCapture = useCallback(
-    (uri: string) => {
-      setCapturedUri(uri);
-      setIsCapturing(false);
-      console.log(successMessage || "Captured!", `Content captured: ${uri}`);
+  useEffect(
+    () => () => {
+      requestId.current++;
     },
-    [successMessage],
+    [],
   );
 
-  const onCaptureFailure = useCallback((error: Error) => {
-    setIsCapturing(false);
-    console.error("Capture Failed", `Error: ${error.message}`);
-  }, []);
+  useEffect(() => {
+    if (capture?.temporary) {
+      return () => releaseCapture(capture.uri);
+    }
+  }, [capture]);
 
   const startCapture = useCallback(
     async (options: CaptureOptions = {}) => {
@@ -34,31 +37,44 @@ export const useViewShotCapture = (successMessage?: string) => {
         return;
       }
 
+      const id = ++requestId.current;
+      const temporary = !options.result || options.result === "tmpfile";
       setIsCapturing(true);
-      setCapturedUri(null);
+      setCapture(null);
 
       try {
-        const captureOptions = {
-          format: "png" as const,
+        const uri = await captureRef(viewShotRef, {
+          format: "png",
           quality: 0.8,
           ...options,
-        };
-        const uri = await captureRef(viewShotRef, captureOptions);
-        onCapture(uri);
+        });
+        if (id !== requestId.current) {
+          if (temporary) releaseCapture(uri);
+          return;
+        }
+        setCapture({uri, temporary});
+        setIsCapturing(false);
+        console.log(successMessage || "Captured!");
       } catch (error) {
-        onCaptureFailure(error as Error);
+        if (id !== requestId.current) return;
+        setIsCapturing(false);
+        console.error(
+          "Capture Failed",
+          error instanceof Error ? error.message : String(error),
+        );
       }
     },
-    [onCapture, onCaptureFailure],
+    [successMessage],
   );
 
   const resetCapture = useCallback(() => {
-    setCapturedUri(null);
+    requestId.current++;
+    setCapture(null);
     setIsCapturing(false);
   }, []);
 
   return {
-    capturedUri,
+    capturedUri: capture?.uri ?? null,
     isCapturing,
     viewShotRef,
     startCapture,

--- a/example/src/components/shared/hooks/useViewShotCapture.ts
+++ b/example/src/components/shared/hooks/useViewShotCapture.ts
@@ -1,31 +1,34 @@
-import { useState, useCallback, useRef } from 'react';
-import { captureRef } from 'react-native-view-shot';
+import { useState, useCallback, useRef, useEffect } from 'react';
+import {
+  captureRef,
+  releaseCapture,
+  type CaptureOptions,
+  type ViewShotRef,
+} from 'react-native-view-shot';
 
-export interface CaptureOptions {
-  format?: 'png' | 'jpg' | 'webm';
-  quality?: number;
-  result?: 'tmpfile' | 'base64' | 'zip-base64' | 'data-uri';
-  handleGLSurfaceViewOnAndroid?: boolean;
-}
+export type { CaptureOptions } from 'react-native-view-shot';
 
 export const useViewShotCapture = (successMessage?: string) => {
-  const [capturedUri, setCapturedUri] = useState<string | null>(null);
+  const [capture, setCapture] = useState<{
+    uri: string;
+    temporary: boolean;
+  } | null>(null);
   const [isCapturing, setIsCapturing] = useState(false);
-  const viewShotRef = useRef<any>(null);
+  const viewShotRef = useRef<ViewShotRef | null>(null);
+  const requestId = useRef(0);
 
-  const onCapture = useCallback(
-    (uri: string) => {
-      setCapturedUri(uri);
-      setIsCapturing(false);
-      console.log(successMessage || 'Captured!', `Content captured: ${uri}`);
+  useEffect(
+    () => () => {
+      requestId.current++;
     },
-    [successMessage],
+    [],
   );
 
-  const onCaptureFailure = useCallback((error: Error) => {
-    setIsCapturing(false);
-    console.error('Capture Failed', `Error: ${error.message}`);
-  }, []);
+  useEffect(() => {
+    if (capture?.temporary) {
+      return () => releaseCapture(capture.uri);
+    }
+  }, [capture]);
 
   const startCapture = useCallback(
     async (options: CaptureOptions = {}) => {
@@ -34,31 +37,44 @@ export const useViewShotCapture = (successMessage?: string) => {
         return;
       }
 
+      const id = ++requestId.current;
+      const temporary = !options.result || options.result === 'tmpfile';
       setIsCapturing(true);
-      setCapturedUri(null);
+      setCapture(null);
 
       try {
-        const captureOptions = {
-          format: 'png' as const,
+        const uri = await captureRef(viewShotRef, {
+          format: 'png',
           quality: 0.8,
           ...options,
-        };
-        const uri = await captureRef(viewShotRef, captureOptions);
-        onCapture(uri);
+        });
+        if (id !== requestId.current) {
+          if (temporary) releaseCapture(uri);
+          return;
+        }
+        setCapture({ uri, temporary });
+        setIsCapturing(false);
+        console.log(successMessage || 'Captured!');
       } catch (error) {
-        onCaptureFailure(error as Error);
+        if (id !== requestId.current) return;
+        setIsCapturing(false);
+        console.error(
+          'Capture Failed',
+          error instanceof Error ? error.message : String(error),
+        );
       }
     },
-    [onCapture, onCaptureFailure],
+    [successMessage],
   );
 
   const resetCapture = useCallback(() => {
-    setCapturedUri(null);
+    requestId.current++;
+    setCapture(null);
     setIsCapturing(false);
   }, []);
 
   return {
-    capturedUri,
+    capturedUri: capture?.uri ?? null,
     isCapturing,
     viewShotRef,
     startCapture,


### PR DESCRIPTION
## Fixes

Give each shared example capture request an identity, ignore stale success/failure after reset or replacement, release orphaned/current temporary captures, and avoid logging full base64 images. Use the library’s exported capture option and ref types.

## Compatibility / observable changes

Example-only behavior. The most recent request owns the displayed preview and busy state. Inline base64/data-URI results are not passed to releaseCapture. Native and Windows example hooks remain equivalent.

## Verification

Fourteen actual React hook checks cover reset, overlapping success/failure, replacement, unmount, file release and inline-data controls.

This patch was applied independently to upstream commit `6acbec50a5e3cab7d668711d757c52cfdc791c76` and passed its targeted external actual-source diagnostics. Across the focused patches, 119 such checks pass. Java/Objective-C diagnostics use controlled bridge/platform doubles or owned filesystem fixtures; they are not substitutes for physical-device rendering tests.

Combined branch checks:

- Existing JS suite: 4 suites, 46 tests pass.
- TypeScript, ESLint (zero warnings), full Prettier check and library build pass.
- Existing Android unit suite: 62 tests pass; Android Debug example build passes.
- Existing Windows managed helper suite: 16 tests pass on .NET 8.
- Unsigned iOS Simulator example build passes. Native tests: 13/14 pass; the one intentional old-behavior assertion conflict is described below.
- Android and iOS production Metro bundles pass. Web production build passes with three bundle-size warnings.
- React 18.3.1: all 21 applicable JS diagnostic controls pass; React 19 includes callback-ref cleanup coverage.

The separate iOS cleanup patch intentionally makes the existing test named `testReleaseCapture_currentlyDeletesPrefixOnlyImposterDirectories_KNOWN_LOOSE_GUARD` fail because it asserts the unsafe old behavior. That patch is kept in a separate draft PR. No checked-in test/spec or snapshot files were added, modified, regenerated or disabled.

Windows/Expo native builds, physical-device video/PixelCopy output, and full Detox suites were not run. The full unchanged Playwright suite was run against both baseline and patched builds: both have 9 passes and the same 3 failures. Two Linux-reference screenshot mismatches have byte-identical baseline/patched actual images on macOS. The CORS fixture hard-codes port 3000, occupied by an unrelated local backend; the isolated example uses another port. No snapshots or assertions were changed. React Doctor also reports existing example suggestions and a React-18 ref-cleanup warning; the latter was checked against actual React 18 legacy-ref and React 19 cleanup behavior. No rules were suppressed.

## Scope

- `example/src/components/shared/hooks/useViewShotCapture.ts`
- `example-windows/src/components/shared/hooks/useViewShotCapture.ts`

Unrelated audit changes are submitted separately.
