### PR TITLE
fix(example): use the exported ViewShotRef handle type

### DIFF
--- a/example-expo/App.tsx
+++ b/example-expo/App.tsx
@@ -9,11 +9,11 @@ import {
   Alert,
   Platform,
 } from "react-native";
-import ViewShot, {captureRef} from "react-native-view-shot";
+import ViewShot, {captureRef, type ViewShotRef} from "react-native-view-shot";
 
 export default function App() {
   const viewRef = useRef<View>(null);
-  const viewShotRef = useRef<ViewShot>(null);
+  const viewShotRef = useRef<ViewShotRef>(null);
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [mode, setMode] = useState<"view-ref" | "viewshot">("view-ref");

--- a/example-web/src/screens/ViewShotComponentScreen.tsx
+++ b/example-web/src/screens/ViewShotComponentScreen.tsx
@@ -7,14 +7,14 @@ import {
   ScrollView,
   Image,
 } from "react-native";
-import ViewShot from "react-native-view-shot";
+import ViewShot, {type ViewShotRef} from "react-native-view-shot";
 
 interface Props {
   goBack: () => void;
 }
 
 const ViewShotComponentScreen: React.FC<Props> = ({goBack}) => {
-  const viewShotRef = useRef<ViewShot>(null);
+  const viewShotRef = useRef<ViewShotRef>(null);
   const [capturedUri, setCapturedUri] = useState<string | null>(null);
   const [autoUri, setAutoUri] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/example-windows/src/screens/ScrollViewTestScreen.tsx
+++ b/example-windows/src/screens/ScrollViewTestScreen.tsx
@@ -10,7 +10,7 @@ import {
   FlatList,
   SectionList,
 } from "react-native";
-import ViewShot, {captureRef} from "react-native-view-shot";
+import ViewShot, {captureRef, type ViewShotRef} from "react-native-view-shot";
 import {PreviewContainer} from "../components/shared";
 
 const COLORS = [
@@ -77,9 +77,9 @@ interface SectionState {
 }
 
 const ScrollViewTestScreen: React.FC = () => {
-  const scrollViewRef = useRef<ViewShot>(null);
-  const flatListRef = useRef<ViewShot>(null);
-  const sectionListRef = useRef<ViewShot>(null);
+  const scrollViewRef = useRef<ViewShotRef>(null);
+  const flatListRef = useRef<ViewShotRef>(null);
+  const sectionListRef = useRef<ViewShotRef>(null);
   // Refs for the `snapshotContentContainer` demo — these point at the raw
   // ScrollView / FlatList so the native module can read their content size.
   const contentContainerScrollRef = useRef<ScrollView>(null);
@@ -109,7 +109,7 @@ const ScrollViewTestScreen: React.FC = () => {
     });
 
   const capture = async (
-    ref: React.RefObject<ViewShot | null>,
+    ref: React.RefObject<ViewShotRef | null>,
     setter: (s: SectionState) => void,
   ) => {
     try {

--- a/example/src/screens/ScrollViewTestScreen.tsx
+++ b/example/src/screens/ScrollViewTestScreen.tsx
@@ -10,7 +10,7 @@ import {
   FlatList,
   SectionList,
 } from 'react-native';
-import ViewShot, { captureRef } from 'react-native-view-shot';
+import ViewShot, { captureRef, type ViewShotRef } from 'react-native-view-shot';
 import { PreviewContainer } from '../components/shared';
 
 const COLORS = [
@@ -77,9 +77,9 @@ interface SectionState {
 }
 
 const ScrollViewTestScreen: React.FC = () => {
-  const scrollViewRef = useRef<ViewShot>(null);
-  const flatListRef = useRef<ViewShot>(null);
-  const sectionListRef = useRef<ViewShot>(null);
+  const scrollViewRef = useRef<ViewShotRef>(null);
+  const flatListRef = useRef<ViewShotRef>(null);
+  const sectionListRef = useRef<ViewShotRef>(null);
   // Refs for the `snapshotContentContainer` demo — these point at the raw
   // ScrollView / FlatList so the native module can read their content size.
   const contentContainerScrollRef = useRef<ScrollView>(null);
@@ -109,7 +109,7 @@ const ScrollViewTestScreen: React.FC = () => {
     });
 
   const capture = async (
-    ref: React.RefObject<ViewShot | null>,
+    ref: React.RefObject<ViewShotRef | null>,
     setter: (s: SectionState) => void,
   ) => {
     try {


### PR DESCRIPTION
## Fixes

Replace class-style ViewShot annotations with ViewShotRef in web, Expo, native and Windows examples after the functional-component migration.

## Compatibility / observable changes

Types only; no capture behavior or public declarations change.

## Verification

Checked all affected annotations against the current exported handle and built the library and native/web examples. Windows and Expo native builds are not claimed.

This patch was applied independently to upstream commit `6acbec50a5e3cab7d668711d757c52cfdc791c76` and passed its targeted external actual-source diagnostics. Across the focused patches, 119 such checks pass. Java/Objective-C diagnostics use controlled bridge/platform doubles or owned filesystem fixtures; they are not substitutes for physical-device rendering tests.

Combined branch checks:

- Existing JS suite: 4 suites, 46 tests pass.
- TypeScript, ESLint (zero warnings), full Prettier check and library build pass.
- Existing Android unit suite: 62 tests pass; Android Debug example build passes.
- Existing Windows managed helper suite: 16 tests pass on .NET 8.
- Unsigned iOS Simulator example build passes. Native tests: 13/14 pass; the one intentional old-behavior assertion conflict is described below.
- Android and iOS production Metro bundles pass. Web production build passes with three bundle-size warnings.
- React 18.3.1: all 21 applicable JS diagnostic controls pass; React 19 includes callback-ref cleanup coverage.

The separate iOS cleanup patch intentionally makes the existing test named `testReleaseCapture_currentlyDeletesPrefixOnlyImposterDirectories_KNOWN_LOOSE_GUARD` fail because it asserts the unsafe old behavior. That patch is kept in a separate draft PR. No checked-in test/spec or snapshot files were added, modified, regenerated or disabled.

Windows/Expo native builds, physical-device video/PixelCopy output, and full Detox suites were not run. The full unchanged Playwright suite was run against both baseline and patched builds: both have 9 passes and the same 3 failures. Two Linux-reference screenshot mismatches have byte-identical baseline/patched actual images on macOS. The CORS fixture hard-codes port 3000, occupied by an unrelated local backend; the isolated example uses another port. No snapshots or assertions were changed. React Doctor also reports existing example suggestions and a React-18 ref-cleanup warning; the latter was checked against actual React 18 legacy-ref and React 19 cleanup behavior. No rules were suppressed.

## Scope

- `example-web/src/screens/ViewShotComponentScreen.tsx`
- `example/src/screens/ScrollViewTestScreen.tsx`
- `example-windows/src/screens/ScrollViewTestScreen.tsx`
- `example-expo/App.tsx`

Unrelated audit changes are submitted separately.
