### PR TITLE
fix(example): preserve JPEG extensions when downloading captures

### DIFF
--- a/example-web/src/screens/BasicTestScreen.tsx
+++ b/example-web/src/screens/BasicTestScreen.tsx
@@ -56,7 +56,8 @@ const BasicTestScreen: React.FC<Props> = ({goBack}) => {
 
     const link = document.createElement("a");
     link.href = imageUri;
-    link.download = `viewshot-${Date.now()}.png`;
+    const extension = imageUri.startsWith("data:image/jpeg;") ? "jpg" : "png";
+    link.download = `viewshot-${Date.now()}.${extension}`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);


### PR DESCRIPTION
## Fixes

Choose the download extension from the actual capture data URI rather than always naming downloaded images .png.

## Compatibility / observable changes

Example only. JPEG downloads now end in .jpg; PNG remains .png.

## Verification

Actual download-handler checks pass for both JPEG and PNG.

This patch was applied independently to upstream commit `6acbec50a5e3cab7d668711d757c52cfdc791c76` and passed its targeted external actual-source diagnostics. Across the focused patches, 119 such checks pass. Java/Objective-C diagnostics use controlled bridge/platform doubles or owned filesystem fixtures; they are not substitutes for physical-device rendering tests.

Combined branch checks:

- Existing JS suite: 4 suites, 46 tests pass.
- TypeScript, ESLint (zero warnings), full Prettier check and library build pass.
- Existing Android unit suite: 62 tests pass; Android Debug example build passes.
- Existing Windows managed helper suite: 16 tests pass on .NET 8.
- Unsigned iOS Simulator example build passes. Native tests: 13/14 pass; the one intentional old-behavior assertion conflict is described below.
- Android and iOS production Metro bundles pass. Web production build passes with three bundle-size warnings.
- React 18.3.1: all 21 applicable JS diagnostic controls pass; React 19 includes callback-ref cleanup coverage.

The separate iOS cleanup patch intentionally makes the existing test named `testReleaseCapture_currentlyDeletesPrefixOnlyImposterDirectories_KNOWN_LOOSE_GUARD` fail because it asserts the unsafe old behavior. That patch is kept in a separate draft PR. No checked-in test/spec or snapshot files were added, modified, regenerated or disabled.

Windows/Expo native builds, physical-device video/PixelCopy output, and full Detox suites were not run. The full unchanged Playwright suite was run against both baseline and patched builds: both have 9 passes and the same 3 failures. Two Linux-reference screenshot mismatches have byte-identical baseline/patched actual images on macOS. The CORS fixture hard-codes port 3000, occupied by an unrelated local backend; the isolated example uses another port. No snapshots or assertions were changed. React Doctor also reports existing example suggestions and a React-18 ref-cleanup warning; the latter was checked against actual React 18 legacy-ref and React 19 cleanup behavior. No rules were suppressed.

## Scope

- `example-web/src/screens/BasicTestScreen.tsx`

Unrelated audit changes are submitted separately.
