### PR TITLE
fix(example): stop deleting dependencies through the package symlink

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "ViewShotExample",
       "version": "0.0.1",
-      "hasInstallScript": true,
       "dependencies": {
         "@react-native/new-app-screen": "0.84.1",
         "@react-navigation/native": "^7.1.33",

--- a/example/package.json
+++ b/example/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "postinstall": "rm -rf node_modules/react-native-view-shot/node_modules/{react,react-native}",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "lint": "eslint .",


### PR DESCRIPTION
## Fixes

Remove the example postinstall deletion hook. The file:.. dependency is a symlink to the repository, so brace-expanding shells can delete the library’s own React/React Native development dependencies. Metro already excludes those parent copies.

## Compatibility / observable changes

Example setup only. No dependency versions change; the existing Metro blocklist remains the duplicate-React boundary.

## Verification

Owned filesystem fixture reproduces baseline deletion of root development dependencies and verifies preservation after removal. Both actual native production Metro bundles pass with parent dependencies still present.

This patch was applied independently to upstream commit `6acbec50a5e3cab7d668711d757c52cfdc791c76` and passed its targeted external actual-source diagnostics. Across the focused patches, 119 such checks pass. Java/Objective-C diagnostics use controlled bridge/platform doubles or owned filesystem fixtures; they are not substitutes for physical-device rendering tests.

Combined branch checks:

- Existing JS suite: 4 suites, 46 tests pass.
- TypeScript, ESLint (zero warnings), full Prettier check and library build pass.
- Existing Android unit suite: 62 tests pass; Android Debug example build passes.
- Existing Windows managed helper suite: 16 tests pass on .NET 8.
- Unsigned iOS Simulator example build passes. Native tests: 13/14 pass; the one intentional old-behavior assertion conflict is described below.
- Android and iOS production Metro bundles pass. Web production build passes with three bundle-size warnings.
- React 18.3.1: all 21 applicable JS diagnostic controls pass; React 19 includes callback-ref cleanup coverage.

The separate iOS cleanup patch intentionally makes the existing test named `testReleaseCapture_currentlyDeletesPrefixOnlyImposterDirectories_KNOWN_LOOSE_GUARD` fail because it asserts the unsafe old behavior. That patch is kept in a separate draft PR. No checked-in test/spec or snapshot files were added, modified, regenerated or disabled.

Windows/Expo native builds, physical-device video/PixelCopy output, and full Detox suites were not run. The full unchanged Playwright suite was run against both baseline and patched builds: both have 9 passes and the same 3 failures. Two Linux-reference screenshot mismatches have byte-identical baseline/patched actual images on macOS. The CORS fixture hard-codes port 3000, occupied by an unrelated local backend; the isolated example uses another port. No snapshots or assertions were changed. React Doctor also reports existing example suggestions and a React-18 ref-cleanup warning; the latter was checked against actual React 18 legacy-ref and React 19 cleanup behavior. No rules were suppressed.

## Scope

- `example/package.json`
- `example/package-lock.json`

Unrelated audit changes are submitted separately.
