### PR TITLE
fix(tooling): import only unambiguous actual CI snapshots

### DIFF
--- a/example-web/scripts/README.md
+++ b/example-web/scripts/README.md
@@ -28,9 +28,10 @@ When the CI generates new snapshots for Linux (chromium-linux), you can easily i
 ### What it does
 
 1. Downloads the `web-snapshots-actual` artifact from the specified CI run
-2. Extracts the snapshots
-3. Copies them to `e2e/snapshots/reference/viewshot.spec.ts-snapshots/`
-4. Renames `-actual.png` files to the standard naming convention
+2. Stages only `*-actual.png` images; expected/diff images are ignored
+3. Rejects empty or duplicate-name artifacts before changing references
+4. Copies the staged images to `e2e/snapshots/reference/viewshot.spec.ts-snapshots/`, dropping the `-actual` suffix
+5. Removes its temporary download directory on exit
 
 ### After running
 
@@ -38,4 +39,6 @@ When the CI generates new snapshots for Linux (chromium-linux), you can easily i
 2. Commit: `git add e2e/snapshots/reference/ && git commit -m "Update Linux snapshots from CI"`
 3. Push: `git push`
 
-The next CI run will use these new reference snapshots and should pass ✅
+The next CI run uses the reviewed references. Other functional failures or
+unintended visual changes still need investigation; importing images is not a
+substitute for checking correctness.

--- a/example-web/scripts/update-snapshots-from-ci.sh
+++ b/example-web/scripts/update-snapshots-from-ci.sh
@@ -1,75 +1,41 @@
 #!/bin/bash
+# Import actual Linux snapshots from one GitHub Actions run.
+set -euo pipefail
 
-# Script to update Linux snapshots from CI artifacts
-# Usage: ./scripts/update-snapshots-from-ci.sh <run-id>
-
-set -e
-
-if [ -z "$1" ]; then
-  echo "❌ Error: Please provide a GitHub Actions run ID"
-  echo "Usage: $0 <run-id>"
-  echo ""
-  echo "Example: $0 18528005182"
-  echo ""
-  echo "Find the run ID in the GitHub Actions URL:"
-  echo "https://github.com/gre/react-native-view-shot/actions/runs/<RUN_ID>"
+if [ "$#" -ne 1 ] || [[ ! $1 =~ ^[0-9]+$ ]]; then
+  echo "Usage: $0 <numeric-run-id>" >&2
   exit 1
 fi
 
 RUN_ID=$1
 ARTIFACT_NAME="web-snapshots-actual"
 SNAPSHOT_DIR="e2e/snapshots/reference/viewshot.spec.ts-snapshots"
+DOWNLOAD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/viewshot-snapshots.XXXXXX")
+trap 'rm -rf -- "$DOWNLOAD_DIR"' EXIT
 
-echo "🔍 Fetching artifacts from run $RUN_ID..."
-
-# Download the artifact
 cd "$(dirname "$0")/.."
-gh run download "$RUN_ID" -n "$ARTIFACT_NAME" -D /tmp/playwright-snapshots || {
-  echo "❌ Failed to download artifact '$ARTIFACT_NAME'"
-  echo ""
-  echo "💡 Make sure:"
-  echo "  1. The run ID is correct"
-  echo "  2. The artifact exists (may take a few minutes after test completion)"
-  echo "  3. You have GitHub CLI (gh) installed and authenticated"
-  exit 1
-}
+echo "Fetching $ARTIFACT_NAME from run $RUN_ID..."
+gh run download "$RUN_ID" -n "$ARTIFACT_NAME" -D "$DOWNLOAD_DIR/artifact"
 
-echo "✅ Artifact downloaded to /tmp/playwright-snapshots"
+# Validate all destinations before changing any checked-in reference image.
+mkdir "$DOWNLOAD_DIR/staged"
+count=0
+while IFS= read -r -d '' file; do
+  filename=${file##*/}
+  destination="$DOWNLOAD_DIR/staged/${filename%-actual.png}.png"
+  if [ -e "$destination" ]; then
+    echo "Duplicate snapshot destination: ${filename%-actual.png}.png" >&2
+    exit 1
+  fi
+  cp "$file" "$destination"
+  count=$((count + 1))
+done < <(find "$DOWNLOAD_DIR/artifact" -type f -name '*-actual.png' -print0)
 
-# Create snapshot directory if it doesn't exist
-mkdir -p "$SNAPSHOT_DIR"
-
-# Copy actual snapshots to reference directory
-if [ -d "/tmp/playwright-snapshots" ]; then
-  echo "📂 Copying snapshots to $SNAPSHOT_DIR..."
-  
-  # Find all PNG files and copy them
-  find /tmp/playwright-snapshots -name "*.png" | while read -r file; do
-    filename=$(basename "$file")
-    
-    # If it's an -actual.png file, rename it to the standard name
-    if [[ $filename == *"-actual.png" ]]; then
-      newname="${filename%-actual.png}.png"
-      echo "  → $newname"
-      cp "$file" "$SNAPSHOT_DIR/$newname"
-    else
-      echo "  → $filename"
-      cp "$file" "$SNAPSHOT_DIR/$filename"
-    fi
-  done
-  
-  echo ""
-  echo "✅ Snapshots updated successfully!"
-  echo ""
-  echo "📋 Next steps:"
-  echo "  1. Review the changes: git diff $SNAPSHOT_DIR"
-  echo "  2. Commit the new snapshots: git add $SNAPSHOT_DIR && git commit -m 'Update Linux snapshots from CI'"
-  echo "  3. Push: git push"
-  
-  # Clean up
-  rm -rf /tmp/playwright-snapshots
-else
-  echo "❌ No snapshots found in artifact"
+if [ "$count" -eq 0 ]; then
+  echo "No actual snapshots found in artifact." >&2
   exit 1
 fi
 
+mkdir -p "$SNAPSHOT_DIR"
+cp "$DOWNLOAD_DIR/staged/"*.png "$SNAPSHOT_DIR/"
+echo "Updated $count snapshots. Review git diff -- $SNAPSHOT_DIR before committing."


### PR DESCRIPTION
## Fixes

Download into an owned temporary directory, stage only *-actual.png files, reject duplicate destinations before changing references, preserve whitespace/newline names and clean up on every exit.

## Compatibility / observable changes

Tooling only. Empty or ambiguous artifacts now fail without modifying references. Expected/diff images and stale shared-directory files are never imported. No CI snapshots were regenerated or committed.

## Verification

Five isolated shell/filesystem fixtures cover mixed artifact contents, duplicate names, empty artifacts, unusual names and unrelated stale downloads.

This patch was applied independently to upstream commit `6acbec50a5e3cab7d668711d757c52cfdc791c76` and passed its targeted external actual-source diagnostics. Across the focused patches, 119 such checks pass. Java/Objective-C diagnostics use controlled bridge/platform doubles or owned filesystem fixtures; they are not substitutes for physical-device rendering tests.

Combined branch checks:

- Existing JS suite: 4 suites, 46 tests pass.
- TypeScript, ESLint (zero warnings), full Prettier check and library build pass.
- Existing Android unit suite: 62 tests pass; Android Debug example build passes.
- Existing Windows managed helper suite: 16 tests pass on .NET 8.
- Unsigned iOS Simulator example build passes. Native tests: 13/14 pass; the one intentional old-behavior assertion conflict is described below.
- Android and iOS production Metro bundles pass. Web production build passes with three bundle-size warnings.
- React 18.3.1: all 21 applicable JS diagnostic controls pass; React 19 includes callback-ref cleanup coverage.

The separate iOS cleanup patch intentionally makes the existing test named `testReleaseCapture_currentlyDeletesPrefixOnlyImposterDirectories_KNOWN_LOOSE_GUARD` fail because it asserts the unsafe old behavior. That patch is kept in a separate draft PR. No checked-in test/spec or snapshot files were added, modified, regenerated or disabled.

Windows/Expo native builds, physical-device video/PixelCopy output, and full Detox suites were not run. The full unchanged Playwright suite was run against both baseline and patched builds: both have 9 passes and the same 3 failures. Two Linux-reference screenshot mismatches have byte-identical baseline/patched actual images on macOS. The CORS fixture hard-codes port 3000, occupied by an unrelated local backend; the isolated example uses another port. No snapshots or assertions were changed. React Doctor also reports existing example suggestions and a React-18 ref-cleanup warning; the latter was checked against actual React 18 legacy-ref and React 19 cleanup behavior. No rules were suppressed.

## Scope

- `example-web/scripts/update-snapshots-from-ci.sh`
- `example-web/scripts/README.md`

Unrelated audit changes are submitted separately.
