### PR TITLE
docs: correct capture examples and RAW conversion semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,29 +36,35 @@ npx pod-install
 ## High Level API
 
 ```js
+import React, {useCallback, useEffect, useRef} from "react";
+import {Image, ScrollView, Text} from "react-native";
 import ViewShot from "react-native-view-shot";
 
-function ExampleCaptureOnMountManually {
+function ExampleCaptureOnMountManually() {
   const ref = useRef();
 
   useEffect(() => {
     // on mount
-    ref.current.capture().then(uri => {
-      console.log("do something with ", uri);
-    });
+    ref.current
+      .capture()
+      .then(uri => {
+        console.log("do something with ", uri);
+      })
+      .catch(console.error);
   }, []);
 
   return (
-    <ViewShot ref={ref} options={{ fileName: "Your-File-Name", format: "jpg", quality: 0.9 }}>
+    <ViewShot
+      ref={ref}
+      options={{fileName: "Your-File-Name", format: "jpg", quality: 0.9}}
+    >
       <Text>...Something to rasterize...</Text>
     </ViewShot>
   );
 }
 
 // alternative
-function ExampleCaptureOnMountSimpler {
-  const ref = useRef();
-
+function ExampleCaptureOnMountSimpler() {
   const onCapture = useCallback(uri => {
     console.log("do something with ", uri);
   }, []);
@@ -72,28 +78,29 @@ function ExampleCaptureOnMountSimpler {
 
 // waiting an image
 
-function ExampleWaitingCapture {
+function ExampleWaitingCapture({imageSource}) {
   const ref = useRef();
 
   const onImageLoad = useCallback(() => {
-    ref.current.capture().then(uri => {
-      console.log("do something with ", uri);
-    })
+    ref.current
+      .capture()
+      .then(uri => {
+        console.log("do something with ", uri);
+      })
+      .catch(console.error);
   }, []);
 
   return (
     <ViewShot ref={ref}>
       <Text>...Something to rasterize...</Text>
-      <Image ... onLoad={onImageLoad} />
+      <Image source={imageSource} onLoad={onImageLoad} />
     </ViewShot>
   );
 }
 
 // capture ScrollView content
 // NB: you may need to go the "imperative way" to use snapshotContentContainer with the scrollview ref instead
-function ExampleCaptureOnMountSimpler {
-  const ref = useRef();
-
+function ExampleCaptureScrollContent() {
   const onCapture = useCallback(uri => {
     console.log("do something with ", uri);
   }, []);
@@ -114,7 +121,7 @@ function ExampleCaptureOnMountSimpler {
 - **`options`**: the same options as in `captureRef` method.
 - **`captureMode`** (string):
   - if not defined (default). the capture is not automatic and you need to use the ref and call `capture()` yourself.
-  - `"mount"`. Capture the view once at mount. (It is important to understand image loading won't be waited, in such case you want to use `"none"` with `viewShotRef.capture()` after `Image#onLoad`.)
+  - `"mount"`. Capture the view once at mount. Image loading is not awaited; omit `captureMode` and call `viewShotRef.current.capture()` after `Image#onLoad` when needed.
   - `"continuous"` EXPERIMENTAL, this will capture A LOT of images continuously. For very specific use-cases.
   - `"update"` EXPERIMENTAL, this will capture images each time React redraw (on did update). For very specific use-cases.
 - **`onCapture`**: when a `captureMode` is defined, this callback will be called with the capture result.
@@ -140,7 +147,7 @@ Returns a Promise of the image URI.
 - **`options`** may include:
   - **`fileName`** _(string)_: (Android only) the file name of the file. Must be at least 3 characters long.
   - **`width`** / **`height`** _(number)_: the width and height of the final image (resized from the View bound. don't provide it if you want the original pixel size).
-  - **`format`** _(string)_: either `png` or `jpg` or `webm` (Android). Defaults to `png`.
+  - **`format`** _(string)_: `png` or `jpg`, plus `webp` and `raw` on Android. Defaults to `png`. `webm` is a deprecated alias for `webp`; it produces WebP image data, not a video.
   - **`quality`** _(number)_: the quality. 0.0 - 1.0 (default). (only available on lossy formats like jpg)
   - **`result`** _(string)_, the method you want to use to save the snapshot, one of:
     - `"tmpfile"` (default): save to a temporary file _(that will only exist for as long as the app is running)_.
@@ -232,11 +239,11 @@ Introduced a new image format RAW. it correspond a ARGB array of pixels.
 
 Advantages:
 
-- no compression, so its supper quick. Screenshot taking is less than 16ms;
+- avoids PNG/JPEG compression; capture time still depends on the view and device.
 
 RAW format supported for `zip-base64`, `base64` and `tmpfile` result types.
 
-RAW file on disk saved in format: `${width}:${height}|${base64}` string.
+RAW files contain an ASCII `${width}:${height}|` header followed by binary pixel bytes. The `base64` result instead returns that header followed by base64-encoded pixels; `zip-base64` returns the header followed by base64-encoded, zlib-compressed pixels.
 
 ### zip-base64
 
@@ -246,45 +253,60 @@ approach for capturing screen views and deliver them to the react side.
 
 ### How to work with zip-base64 and RAW format?
 
+Capture in React Native, then send the result and format to a Node.js process for conversion. Node's `fs` and `zlib` modules are not built into React Native.
+
 ```js
-const fs = require("fs");
-const zlib = require("zlib");
-const PNG = require("pngjs").PNG;
-const Buffer = require("buffer").Buffer;
+import {Platform} from "react-native";
+import {captureRef} from "react-native-view-shot";
 
 const format = Platform.OS === "android" ? "raw" : "png";
 const result = Platform.OS === "android" ? "zip-base64" : "base64";
 
-captureRef(this.ref, {result, format}).then(data => {
-  // expected pattern 'width:height|', example: '1080:1731|'
-  const resolution = /^(\d+):(\d+)\|/g.exec(data);
-  const width = (resolution || ["", 0, 0])[1];
-  const height = (resolution || ["", 0, 0])[2];
-  const base64 = data.substr((resolution || [""])[0].length || 0);
+captureRef(viewRef, {result, format})
+  .then(data => {
+    // Send {data, format} to your Node.js conversion process.
+  })
+  .catch(console.error);
+```
 
-  // convert from base64 to Buffer
-  const buffer = Buffer.from(base64, "base64");
-  // un-compress data
-  const inflated = zlib.inflateSync(buffer);
-  // compose PNG
-  const png = new PNG({width, height});
-  png.data = inflated;
-  const pngData = PNG.sync.write(png);
-  // save composed PNG
-  fs.writeFileSync(output, pngData);
-});
+In Node.js:
+
+```js
+const fs = require("node:fs");
+const zlib = require("node:zlib");
+const {PNG} = require("pngjs");
+
+function saveCapture(data, format, outputPath) {
+  let pngData;
+  if (format === "raw") {
+    const resolution = /^(\d+):(\d+)\|/.exec(data);
+    if (!resolution) throw new Error("Missing RAW dimensions");
+    const width = Number(resolution[1]);
+    const height = Number(resolution[2]);
+    const compressed = Buffer.from(data.slice(resolution[0].length), "base64");
+    const pixels = zlib.inflateSync(compressed);
+    if (!width || !height || pixels.length !== width * height * 4) {
+      throw new Error("Invalid RAW dimensions or pixel data");
+    }
+    const png = new PNG({width, height});
+    png.data = pixels;
+    pngData = PNG.sync.write(png);
+  } else {
+    // The iOS/Windows fallback is already PNG, not zlib-compressed RAW.
+    pngData = Buffer.from(data, "base64");
+  }
+  fs.writeFileSync(outputPath, pngData);
+}
 ```
 
 Keep in mind that packaging PNG data is a CPU consuming operation as a `zlib.inflate`.
 
 Hint: use `process.fork()` approach for converting raw data into PNGs.
 
-> Note: code is tested in large commercial project.
-
-> Note #2: Don't forget to add packages into your project:
+> Install the PNG encoder in your Node.js conversion project (`zlib` is built in):
 >
 > ```bash
-> npm install pngjs zlib
+> npm install pngjs
 > ```
 
 ## Troubleshooting / FAQ
@@ -328,20 +350,23 @@ This is because the snapshot image result is in real pixel size where the width/
 A prop may be necessary to properly capture GL Surface View in the view tree:
 
 ```js
-/**
-  * if true and when view is a SurfaceView or have it in the view tree, view will be captured.
-  * False by default, because it can have signoficant performance impact
-  */
-handleGLSurfaceViewOnAndroid?: boolean;
+// Opt in to SurfaceView capture; it can have a significant performance cost.
+captureRef(viewRef, {handleGLSurfaceViewOnAndroid: true});
 ```
 
 ### Trying to share the capture result with `expo-sharing`?
 
-`tmpfile` or the default capture result works best for this. Just be sure to prepend `file://` to result before you call `shareAsync`.
+`tmpfile` or the default capture result works best for this. Add `file://` only when it is absent; Android already returns a file URI.
 
 ```js
 captureRef(viewRef)
-  .then((uri) => Sharing.shareAsync(`file://${uri}`, options)
+  .then(uri =>
+    Sharing.shareAsync(
+      uri.startsWith("file://") ? uri : `file://${uri}`,
+      options,
+    ),
+  )
+  .catch(console.error);
 ```
 
 ---

--- a/example-web/README.md
+++ b/example-web/README.md
@@ -96,19 +96,17 @@ See `.github/workflows/ci.yml` - the `test-web-example` job runs all Playwright 
 
 **CI Artifacts:**
 
-- `web-snapshots-reference`: Current reference snapshots (download to update local snapshots)
-- `web-snapshots-diff`: Visual diffs when tests fail (actual vs expected)
+- `web-snapshots-actual`: Actual, expected and diff images from failed comparisons
 - `playwright-report`: Full HTML test report
 - `playwright-test-results`: Detailed test results
 
 **When snapshots differ:**
 
 - The CI will show a clear message in the GitHub Actions summary
-- Download the `web-snapshots-reference` artifact
-- Replace `example-web/e2e/snapshots/reference/` with the downloaded files
-- Commit the updated snapshots
+- Run `./scripts/update-snapshots-from-ci.sh <RUN_ID>` from `example-web/` to import only the actual images from `web-snapshots-actual`
+- Review every changed reference image and commit only intended visual changes
 
-**Note:** Snapshots are platform-specific (Linux vs macOS). The CI runs on Linux, so you may need to update snapshots when running locally on macOS.
+**Note:** Committed reference images are generated on Linux. Local non-Linux runs use separate platform-suffixed images; do not replace the Linux references with macOS or Windows output. See [snapshot guidance](e2e/snapshots/README.md).
 
 ## Related
 

--- a/example/e2e/README.md
+++ b/example/e2e/README.md
@@ -1,230 +1,61 @@
-# E2E Testing with Detox
+# E2E testing with Detox
 
-## Status
+The native example has Detox scenarios for capture formats, media, scrolling,
+modals and style filters. A successful app build is not proof that these
+interactive or visual checks pass.
 
-### ✅ iOS - Production Ready
+## Current CI configuration
 
-- **All 10 test scenarios passing**
-- Runs in CI via GitHub Actions
-- Comprehensive coverage of all ViewShot features
-- Robust navigation and error handling
+- The iOS Detox job runs after the iOS build, but its test step is non-blocking
+  (`continue-on-error: true`). The workflow records known reporter and
+  snapshot-content-container/style-filter failures. Inspect test results and
+  screenshots rather than treating a green workflow as an all-tests-pass result.
+- Android Detox jobs are commented out in `.github/workflows/ci.yml`. Android
+  library unit tests and the example APK build still run; they do not exercise
+  the Detox scenarios.
+- The Android example enables the new architecture. Do not disable Fabric based
+  on older setup guidance without checking the installed React Native version.
+- Several existing scenarios treat missing success text as best-effort, and the
+  snapshot helper compares compressed file sizes/bytes rather than decoded
+  pixels. These checks do not establish pixel-level rendering correctness.
 
-### 🚧 Android - Working with Known Issues
+## Run locally
 
-- **APK builds:** ✅ Both debug and test APKs build successfully
-- **libfbjni.so fix:** ✅ Duplicate library conflicts resolved
-- **Detox runtime:** ✅ App launches without Fabric crashes (newArchEnabled=false)
-- **Test execution:** ⚠️ Tests run but have element detection issues
-  - Button testIDs not always detected by Detox
-  - Screen navigation sometimes fails
-  - App occasionally crashes between tests
-
-## Running Tests
-
-### iOS (Fully Working)
+Install and build the library and example dependencies first. Start Metro from
+`example/` in a separate terminal, then build and run the matching Detox target:
 
 ```bash
 cd example
+npm run build:e2e:ios
 npm run test:e2e:ios
 ```
 
-To update iOS reference snapshots:
-
 ```bash
 cd example
-UPDATE_SNAPSHOTS=true npm run test:e2e:ios
-```
-
-### Android (Working with Issues)
-
-```bash
-cd example
+npm run build:e2e:android
 npm run test:e2e:android
 ```
 
-To update Android reference snapshots:
+`.detoxrc.js` defines the simulator/emulator names and binary paths. Set
+`IOS_SIMULATOR` or `ANDROID_AVD_NAME` to select an installed device. Android
+setup or runtime failures must be resolved before claiming Android E2E coverage.
 
-```bash
-cd example
-UPDATE_SNAPSHOTS=true npm run test:e2e:android
-```
+## Configuration and helpers
 
-**Note:** Android tests may fail intermittently due to element detection issues. See "Known Issues" section below.
+- `e2e/jest.config.js`: test discovery, timeout, Detox environment and reporters.
+- `e2e/test-config.js`: platform timeouts and expected content.
+- `e2e/setup.js`: shared navigation, capture and logging helpers.
+- `e2e/helpers/`: screenshot comparison and interaction helpers.
+- `e2e/tests/`: the actual scenario assertions.
 
-## Test Coverage
+## Review snapshots
 
-All tests cover the same scenarios on both platforms:
+Native references are separated under `e2e/snapshots/reference/ios/` and
+`e2e/snapshots/reference/android/` because rendering differs by platform.
+To intentionally regenerate references, set `UPDATE_SNAPSHOTS=true` on the
+matching test command, then review every image change before committing it.
+Do not regenerate references merely to hide a regression.
 
-### Basic Tests
-
-1. Basic ViewShot - Simple view capture
-2. Full Screen - Full screen capture
-3. Transparency - Alpha channel handling
-4. File System - Save to device storage
-
-### Media Tests
-
-5. Video - Video player capture
-6. Image - Image component capture
-7. WebView - WebView content capture
-
-### Advanced Tests
-
-8. SVG Inline - Inline SVG rendering
-9. SVG URI - SVG from URI
-10. Modal - Modal overlay capture
-
-## Known Issues
-
-### Android Detox Element Detection
-
-Android tests run but have intermittent element detection issues:
-
-**Problems:**
-
-- `testID` attributes not always detected by Detox on Android
-- `by.text()` matchers sometimes fail with emoji-containing text
-- App crashes with "No activities found" after some test failures
-- Navigation between screens can fail intermittently
-
-**Root Causes:**
-
-1. **testID mapping:** React Native Android doesn't automatically map `testID` to accessibility identifiers like iOS does
-2. **Emoji rendering:** Android text matching with emojis is unreliable
-3. **Activity lifecycle:** React Native Android activity can be destroyed between tests
-
-**Fixes Applied:**
-
-- ✅ Added `accessible={true}` and `accessibilityLabel` to buttons
-- ✅ Disabled Fabric (`newArchEnabled=false`) to avoid Detox crashes
-- ✅ Increased Detox timeouts for React Native initialization
-- ✅ Fixed libfbjni.so duplicate library conflicts
-
-**Recommended Actions:**
-
-1. Use iOS Detox for primary CI/CD validation (fully stable)
-2. Run Android Detox tests as supplementary checks
-3. Consider adding more explicit testIDs to all interactive elements
-4. Investigate using `by.id()` with resource IDs instead of text matchers
-
-## Android Build Fix
-
-The key fix for Android APK builds is in `example/android/app/build.gradle`:
-
-```gradle
-afterEvaluate {
-    tasks.matching {
-        it.name.contains('mergeDebugAndroidTest') &&
-        it.name.contains('JniLibFolders')
-    }.configureEach {
-        doFirst {
-            def gestureHandlerDir = file("${projectDir}/../../node_modules/react-native-gesture-handler/android/build/intermediates/library_jni/debug")
-            if (gestureHandlerDir.exists()) {
-                gestureHandlerDir.eachFileRecurse { file ->
-                    if (file.name == 'libfbjni.so') {
-                        file.delete()
-                    }
-                }
-            }
-        }
-    }
-}
-```
-
-This removes duplicate `libfbjni.so` files from `react-native-gesture-handler` before the merge step, allowing the test APK to build successfully.
-
-## Configuration Files
-
-- `.detoxrc.js` - Detox configuration for both platforms
-- `jest.config.js` - Jest test runner configuration
-- `setup.js` - Global test helpers and utilities
-- `test-config.js` - Platform-specific timeouts and settings
-
-## Helpers
-
-### Navigation
-
-- `navigateToTest(testName)` - Navigate to a test screen
-- `safeNavigateBack()` - Go back with error handling
-- `scrollToButton(buttonId)` - Smart scrolling to find buttons
-
-### Actions
-
-- `safeTap(elementId)` - Tap with visibility check
-- `captureWithRetry(buttonId)` - Capture with retries
-- `waitForElementWithTimeout(element, timeout)` - Wait for element
-
-### Validation
-
-- `SnapshotMatcher` - Image comparison with tolerance
-- **Platform-specific snapshots** - Separate reference images for iOS/Android
-- Platform-specific timeouts (`getPlatformTimeout`)
-- Auto-capture detection and handling
-
-## Snapshot Testing
-
-### Platform-Specific References
-
-Screenshot references are **separated by platform** to account for rendering differences:
-
-```
-snapshots/
-  ├── reference/
-  │   ├── ios/           # iOS reference images
-  │   │   ├── basic_viewshot.png
-  │   │   ├── fullscreen_viewshot.png
-  │   │   └── ...
-  │   └── android/       # Android reference images
-  │       ├── basic_viewshot.png
-  │       └── ...
-  └── output/            # Test outputs (gitignored)
-      ├── ios/
-      └── android/
-```
-
-**Why separate?** iOS and Android render differently:
-
-- Different fonts and antialiasing
-- Different native components
-- Different screen densities
-
-### Updating Reference Images
-
-To regenerate reference images for a platform:
-
-```bash
-# iOS
-cd example
-UPDATE_SNAPSHOTS=true npm run test:e2e:ios
-
-# Android (when working)
-UPDATE_SNAPSHOTS=true npm run test:e2e:android
-```
-
-This will save new screenshots to `snapshots/reference/{platform}/`.
-
-## CI Integration
-
-iOS and Android tests run automatically in GitHub Actions:
-
-**When snapshots differ:**
-
-- The CI will show a clear message in the GitHub Actions summary
-- Download the `detox-snapshots-ios` or `detox-snapshots-android` artifact
-- Replace `example/e2e/snapshots/reference/` with the downloaded files
-- Commit the updated snapshots
-
-**Artifacts available:**
-
-- `detox-snapshots-ios`: iOS reference snapshots (30 days)
-- `detox-snapshots-android`: Android reference snapshots (30 days)
-- `detox-test-results-ios`: iOS test results (7 days)
-- `detox-test-results-android`: Android test results (7 days)
-
-iOS tests run automatically in GitHub Actions:
-
-- On every PR
-- On push to main
-- Results published as artifacts
-
-To enable Android Detox in CI, the runtime issue must be resolved first.
+The iOS CI job uploads `detox-screenshots-ios` and `detox-test-results-ios`.
+These are diagnostic artifacts, not an automatically approved set of replacement
+reference images. Check `.github/workflows/ci.yml` for the current artifact paths.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -81,7 +81,7 @@ export interface ViewShotProperties {
    * - if not defined (default). the capture is not automatic and you need to use the ref and call capture()
    *   yourself.
    * - "mount". Capture the view once at mount. (It is important to understand image loading won't be waited, in
-   *   such case you want to use "none" with viewShotRef.capture() after Image#onLoad.)
+   *   such case omit captureMode and call viewShotRef.current.capture() after Image#onLoad.)
    * - "continuous" EXPERIMENTAL, this will capture A LOT of images continuously. For very specific use-cases.
    * - "update" EXPERIMENTAL, this will capture images each time React redraw (on did update). For very specific
    *   use-cases.


### PR DESCRIPTION
## Fixes

Make the high-level snippets valid JavaScript, document omission of captureMode rather than a nonexistent none value, explain WebP/raw results accurately, distinguish binary RAW files from base64 results, separate native capture from Node conversion, preserve the already-PNG fallback, and avoid duplicate file URI prefixes when sharing. Correct CI/test coverage claims: Android Detox is disabled, iOS Detox is non-blocking, several native assertions are best-effort, and the snapshot helper does not compare decoded pixels. Document the actual web artifact names and preserve Linux references.

## Compatibility / observable changes

Documentation only. No benchmark guarantee is made. Node conversion uses built-in fs/zlib and the optional pngjs package; these are not React Native built-ins.

## Verification

All README JavaScript snippets parse. The Node converter round-trips RAW pixels, preserves an already-encoded PNG, and rejects inconsistent RAW headers.

This patch was applied independently to upstream commit `6acbec50a5e3cab7d668711d757c52cfdc791c76` and passed its targeted external actual-source diagnostics. Across the focused patches, 119 such checks pass. Java/Objective-C diagnostics use controlled bridge/platform doubles or owned filesystem fixtures; they are not substitutes for physical-device rendering tests.

Combined branch checks:

- Existing JS suite: 4 suites, 46 tests pass.
- TypeScript, ESLint (zero warnings), full Prettier check and library build pass.
- Existing Android unit suite: 62 tests pass; Android Debug example build passes.
- Existing Windows managed helper suite: 16 tests pass on .NET 8.
- Unsigned iOS Simulator example build passes. Native tests: 13/14 pass; the one intentional old-behavior assertion conflict is described below.
- Android and iOS production Metro bundles pass. Web production build passes with three bundle-size warnings.
- React 18.3.1: all 21 applicable JS diagnostic controls pass; React 19 includes callback-ref cleanup coverage.

The separate iOS cleanup patch intentionally makes the existing test named `testReleaseCapture_currentlyDeletesPrefixOnlyImposterDirectories_KNOWN_LOOSE_GUARD` fail because it asserts the unsafe old behavior. That patch is kept in a separate draft PR. No checked-in test/spec or snapshot files were added, modified, regenerated or disabled.

Windows/Expo native builds, physical-device video/PixelCopy output, and full Detox suites were not run. The full unchanged Playwright suite was run against both baseline and patched builds: both have 9 passes and the same 3 failures. Two Linux-reference screenshot mismatches have byte-identical baseline/patched actual images on macOS. The CORS fixture hard-codes port 3000, occupied by an unrelated local backend; the isolated example uses another port. No snapshots or assertions were changed. React Doctor also reports existing example suggestions and a React-18 ref-cleanup warning; the latter was checked against actual React 18 legacy-ref and React 19 cleanup behavior. No rules were suppressed.

## Scope

- `README.md`
- `src/index.tsx`
- `example/e2e/README.md`
- `example-web/README.md`

Unrelated audit changes are submitted separately.
