### PR TITLE
fix(windows): read complete capture streams and box JPEG quality correctly

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,10 @@ ios/build/
 example/android/build/
 example/ios/build/
 **/build/
+windows/**/bin/
+windows/**/obj/
+example-windows/windows/**/bin/
+example-windows/windows/**/obj/
 **/.gradle/
 **/.cxx/
 

--- a/windows/RNViewShot/ViewShot.cs
+++ b/windows/RNViewShot/ViewShot.cs
@@ -39,7 +39,19 @@ namespace RNViewShot
                         throw new InvalidOperationException("Capture is too large to base64-encode (" + ras.Size + " bytes)");
                     }
                     var imageBytes = new byte[(int)ras.Size];
-                    await ras.AsStream().ReadAsync(imageBytes, 0, imageBytes.Length);
+                    using (var input = ras.GetInputStreamAt(0).AsStreamForRead())
+                    {
+                        var offset = 0;
+                        while (offset < imageBytes.Length)
+                        {
+                            var read = await input.ReadAsync(imageBytes, offset, imageBytes.Length - offset);
+                            if (read == 0)
+                            {
+                                throw new EndOfStreamException("Capture stream ended before all image bytes were read");
+                            }
+                            offset += read;
+                        }
+                    }
                     var data = Convert.ToBase64String(imageBytes);
                     if (result == "data-uri")
                     {
@@ -77,7 +89,7 @@ namespace RNViewShot
             {
                 var propertySet = new BitmapPropertySet
                 {
-                    { "ImageQuality", new BitmapTypedValue(quality, Windows.Foundation.PropertyType.Single) },
+                    { "ImageQuality", new BitmapTypedValue((float)quality, Windows.Foundation.PropertyType.Single) },
                 };
                 encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.JpegEncoderId, stream, propertySet);
             }


### PR DESCRIPTION
## Fixes

Read from offset zero, continue through partial reads, reject premature EOF, dispose the temporary input adapter, and box JPEG ImageQuality as Single to match the declared Windows property type. Exclude generated .NET bin/obj outputs from formatting, so running the existing Windows unit suite does not break the next format check.

## Compatibility / observable changes

No public API change. Base64/data-URI captures now include all encoded bytes; truncated streams reject instead of silently producing zero-padded data. JPEG quality keeps its documented 0–1 range. Temporary-file output is unchanged.

## Verification

Seven actual-source C# 7.3/.NET 8 checks cover stream position, partial reads, truncated input, MIME, adapter cleanup and boxed quality; six fail on the baseline. The existing 16 Windows helper tests pass. Windows SDK/XAML rendering and a complete Windows app build were not run. Microsoft documents ImageQuality as Single: https://learn.microsoft.com/en-us/windows/apps/develop/media-authoring-processing/bitmapencoder-options-reference

This patch was applied independently to upstream commit `6acbec50a5e3cab7d668711d757c52cfdc791c76` and passed its targeted external actual-source diagnostics. Across the focused patches, 119 such checks pass. Java/Objective-C diagnostics use controlled bridge/platform doubles or owned filesystem fixtures; they are not substitutes for physical-device rendering tests.

Combined branch checks:

- Existing JS suite: 4 suites, 46 tests pass.
- TypeScript, ESLint (zero warnings), full Prettier check and library build pass.
- Existing Android unit suite: 62 tests pass; Android Debug example build passes.
- Existing Windows managed helper suite: 16 tests pass on .NET 8.
- Unsigned iOS Simulator example build passes. Native tests: 13/14 pass; the one intentional old-behavior assertion conflict is described below.
- Android and iOS production Metro bundles pass. Web production build passes with three bundle-size warnings.
- React 18.3.1: all 21 applicable JS diagnostic controls pass; React 19 includes callback-ref cleanup coverage.

The separate iOS cleanup patch intentionally makes the existing test named `testReleaseCapture_currentlyDeletesPrefixOnlyImposterDirectories_KNOWN_LOOSE_GUARD` fail because it asserts the unsafe old behavior. That patch is kept in a separate draft PR. No checked-in test/spec or snapshot files were added, modified, regenerated or disabled.

Windows/Expo native builds, physical-device video/PixelCopy output, and full Detox suites were not run. The full unchanged Playwright suite was run against both baseline and patched builds: both have 9 passes and the same 3 failures. Two Linux-reference screenshot mismatches have byte-identical baseline/patched actual images on macOS. The CORS fixture hard-codes port 3000, occupied by an unrelated local backend; the isolated example uses another port. No snapshots or assertions were changed. React Doctor also reports existing example suggestions and a React-18 ref-cleanup warning; the latter was checked against actual React 18 legacy-ref and React 19 cleanup behavior. No rules were suppressed.

## Scope

- `windows/RNViewShot/ViewShot.cs`
- `.prettierignore`

Unrelated audit changes are submitted separately.
