### PR TITLE
fix(example): report supported image formats and failed loads accurately

### DIFF
--- a/example-web/src/screens/CORSImageTestScreen.tsx
+++ b/example-web/src/screens/CORSImageTestScreen.tsx
@@ -30,11 +30,16 @@ const CORSImageTestScreen: React.FC<Props> = ({goBack}) => {
   const [capturedUri, setCapturedUri] = useState<string | null>(null);
   const [isCapturing, setIsCapturing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [imagesLoaded, setImagesLoaded] = useState<Record<number, boolean>>({});
+  const [imageStatus, setImageStatus] = useState<
+    Record<number, "loaded" | "error">
+  >({});
 
-  const allImagesLoaded =
-    Object.keys(imagesLoaded).length === CROSS_ORIGIN_IMAGES.length &&
-    Object.values(imagesLoaded).every(Boolean);
+  const allImagesLoaded = CROSS_ORIGIN_IMAGES.every(
+    (_, index) => imageStatus[index] === "loaded",
+  );
+  const hasImageError = CROSS_ORIGIN_IMAGES.some(
+    (_, index) => imageStatus[index] === "error",
+  );
 
   const captureView = async () => {
     setIsCapturing(true);
@@ -86,13 +91,23 @@ const CORSImageTestScreen: React.FC<Props> = ({goBack}) => {
                 style={styles.testImage}
                 resizeMode="cover"
                 onLoad={() =>
-                  setImagesLoaded(prev => ({...prev, [index]: true}))
+                  setImageStatus(prev => ({...prev, [index]: "loaded"}))
+                }
+                onError={() =>
+                  setImageStatus(prev => ({...prev, [index]: "error"}))
                 }
               />
               <View style={styles.imageInfo}>
                 <Text style={styles.cardText}>{img.label}</Text>
-                <Text style={styles.statusText}>
-                  {imagesLoaded[index] ? "Loaded" : "Loading..."}
+                <Text
+                  style={styles.statusText}
+                  accessibilityLiveRegion="polite"
+                >
+                  {imageStatus[index] === "loaded"
+                    ? "Loaded"
+                    : imageStatus[index] === "error"
+                      ? "Failed to load"
+                      : "Loading..."}
                 </Text>
               </View>
             </View>
@@ -122,9 +137,11 @@ const CORSImageTestScreen: React.FC<Props> = ({goBack}) => {
           <Text style={styles.captureButtonText}>
             {isCapturing
               ? "Capturing..."
-              : !allImagesLoaded
-                ? "Waiting for images to load..."
-                : "Capture with CORS images"}
+              : hasImageError
+                ? "Some images failed to load"
+                : !allImagesLoaded
+                  ? "Waiting for images to load..."
+                  : "Capture with CORS images"}
           </Text>
         </TouchableOpacity>
 

--- a/example-web/src/screens/ImageTestScreen.tsx
+++ b/example-web/src/screens/ImageTestScreen.tsx
@@ -27,8 +27,6 @@ const ImageTestScreen: React.FC<Props> = ({goBack}) => {
           format,
           quality: 1.0, // Maximum quality
           result: "data-uri",
-          // For web, we can add pixelRatio for higher resolution
-          ...(typeof window !== "undefined" && {pixelRatio: 4}),
         });
         setCapturedUri(uri);
         console.log("Captured with format:", format);
@@ -119,7 +117,10 @@ const ImageTestScreen: React.FC<Props> = ({goBack}) => {
                 styles.formatButton,
                 format === "png" && styles.formatButtonActive,
               ]}
-              onPress={() => setFormat("png")}
+              onPress={() => {
+                setFormat("png");
+                setCapturedUri(null);
+              }}
             >
               <Text
                 style={[
@@ -136,7 +137,10 @@ const ImageTestScreen: React.FC<Props> = ({goBack}) => {
                 styles.formatButton,
                 format === "jpg" && styles.formatButtonActive,
               ]}
-              onPress={() => setFormat("jpg")}
+              onPress={() => {
+                setFormat("jpg");
+                setCapturedUri(null);
+              }}
             >
               <Text
                 style={[
@@ -170,7 +174,9 @@ const ImageTestScreen: React.FC<Props> = ({goBack}) => {
                 resizeMode="contain"
               />
               <Text style={styles.previewInfo}>
-                Format: {format.toUpperCase()} | Quality: 0.9
+                Format:{" "}
+                {capturedUri.startsWith("data:image/jpeg;") ? "JPG" : "PNG"}
+                {" | Quality: 1"}
               </Text>
             </View>
           )}

--- a/example-windows/src/screens/FSTestScreen.tsx
+++ b/example-windows/src/screens/FSTestScreen.tsx
@@ -36,7 +36,8 @@ const FSTestScreen: React.FC = () => {
   };
 
   const cycleFormat = () => {
-    const formats: Array<"png" | "jpg" | "webm"> = ["png", "jpg", "webm"];
+    const formats: Array<"png" | "jpg" | "webm"> =
+      Platform.OS === "android" ? ["png", "jpg", "webm"] : ["png", "jpg"];
     const currentIndex = formats.indexOf(saveFormat);
     const nextIndex = (currentIndex + 1) % formats.length;
     setSaveFormat(formats[nextIndex]);

--- a/example-windows/src/screens/ImageTestScreen.tsx
+++ b/example-windows/src/screens/ImageTestScreen.tsx
@@ -30,7 +30,8 @@ const ImageTestScreen: React.FC = () => {
 
   const onCapture = useCallback(
     (base64: string) => {
-      const uri = `data:image/${captureFormat};base64,${base64}`;
+      const mimeType = captureFormat === "jpg" ? "jpeg" : captureFormat;
+      const uri = `data:image/${mimeType};base64,${base64}`;
       setCapturedUri(uri);
       setIsCapturing(false);
     },

--- a/example/src/screens/FSTestScreen.tsx
+++ b/example/src/screens/FSTestScreen.tsx
@@ -36,7 +36,8 @@ const FSTestScreen: React.FC = () => {
   };
 
   const cycleFormat = () => {
-    const formats: Array<'png' | 'jpg' | 'webm'> = ['png', 'jpg', 'webm'];
+    const formats: Array<'png' | 'jpg' | 'webm'> =
+      Platform.OS === 'android' ? ['png', 'jpg', 'webm'] : ['png', 'jpg'];
     const currentIndex = formats.indexOf(saveFormat);
     const nextIndex = (currentIndex + 1) % formats.length;
     setSaveFormat(formats[nextIndex]);

--- a/example/src/screens/ImageTestScreen.tsx
+++ b/example/src/screens/ImageTestScreen.tsx
@@ -27,7 +27,8 @@ const ImageTestScreen: React.FC = () => {
 
   const onCapture = useCallback(
     (base64: string) => {
-      const uri = `data:image/${captureFormat};base64,${base64}`;
+      const mimeType = captureFormat === 'jpg' ? 'jpeg' : captureFormat;
+      const uri = `data:image/${mimeType};base64,${base64}`;
       setCapturedUri(uri);
       setIsCapturing(false);
     },


### PR DESCRIPTION
## Fixes

Use image/jpeg for native/Windows JPEG previews, restrict the legacy webm option to Android, remove the unsupported web pixelRatio option, show the actual output format/quality and clear old format previews, and report failed cross-origin image loads instead of waiting indefinitely.

## Compatibility / observable changes

Example-only corrections. No API, dependency, layout or styling changes. Failed remote images keep capture disabled and expose a polite live status; a later successful load restores normal capture.

## Verification

Ten actual React-rendered checks pass across native, Windows and web examples; eight fail on the baseline. Checks cover MIME, platform-specific format cycling, supported capture options, preview metadata/reset, and failed/successful image event controls. No assistive-technology or full Windows rendering claim.

This patch was applied independently to upstream commit `6acbec50a5e3cab7d668711d757c52cfdc791c76` and passed its targeted external actual-source diagnostics. Across the focused patches, 119 such checks pass. Java/Objective-C diagnostics use controlled bridge/platform doubles or owned filesystem fixtures; they are not substitutes for physical-device rendering tests.

Combined branch checks:

- Existing JS suite: 4 suites, 46 tests pass.
- TypeScript, ESLint (zero warnings), full Prettier check and library build pass.
- Existing Android unit suite: 62 tests pass; Android Debug example build passes.
- Existing Windows managed helper suite: 16 tests pass on .NET 8.
- Unsigned iOS Simulator example build passes. Native tests: 13/14 pass; the one intentional old-behavior assertion conflict is described below.
- Android and iOS production Metro bundles pass. Web production build passes with three bundle-size warnings.
- React 18.3.1: all 21 applicable JS diagnostic controls pass; React 19 includes callback-ref cleanup coverage.

The separate iOS cleanup patch intentionally makes the existing test named `testReleaseCapture_currentlyDeletesPrefixOnlyImposterDirectories_KNOWN_LOOSE_GUARD` fail because it asserts the unsafe old behavior. That patch is kept in a separate draft PR. No checked-in test/spec or snapshot files were added, modified, regenerated or disabled.

Windows/Expo native builds, physical-device video/PixelCopy output, and full Detox suites were not run. The full unchanged Playwright suite was run against both baseline and patched builds: both have 9 passes and the same 3 failures. Two Linux-reference screenshot mismatches have byte-identical baseline/patched actual images on macOS. The CORS fixture hard-codes port 3000, occupied by an unrelated local backend; the isolated example uses another port. No snapshots or assertions were changed. React Doctor also reports existing example suggestions and a React-18 ref-cleanup warning; the latter was checked against actual React 18 legacy-ref and React 19 cleanup behavior. No rules were suppressed.

## Scope

- `example/src/screens/ImageTestScreen.tsx`
- `example-windows/src/screens/ImageTestScreen.tsx`
- `example/src/screens/FSTestScreen.tsx`
- `example-windows/src/screens/FSTestScreen.tsx`
- `example-web/src/screens/ImageTestScreen.tsx`
- `example-web/src/screens/CORSImageTestScreen.tsx`

Unrelated audit changes are submitted separately.
